### PR TITLE
build: agent-js as peer dependency of core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,9 +42,10 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.2.tgz",
-      "integrity": "sha512-KLRWEjeU9SyyaS7IBVJ9ZUcufxufr55e/kRIyClK157+0pkTG9a8xKjUIMx3QzKvLsqqzXL238nWwdoP6jAD8g==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.3.tgz",
+      "integrity": "sha512-q410aNLoOA1ZkwdAMgSo6t++pjISn9TfSybRXhPRI5Ume7eG6+6qYr/rlvcXy7Nb2+Ar7LTsHNn34IULfjni7w==",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.3.1",
         "base64-arraybuffer": "^0.2.0",
@@ -52,38 +53,54 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.19.2",
-        "@dfinity/principal": "^0.19.2"
+        "@dfinity/candid": "^0.19.3",
+        "@dfinity/principal": "^0.19.3"
+      }
+    },
+    "node_modules/@dfinity/auth-client": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.19.3.tgz",
+      "integrity": "sha512-fN5sZXkO3pzsBE+dVOD57Nv59n2H5jtK1JRWP7NEKmxgUk/dOOX6I5ZwUYVOQA3VcJ3azvV9SbXUHSgaFcf0sw==",
+      "peer": true,
+      "dependencies": {
+        "idb": "^7.0.2"
+      },
+      "peerDependencies": {
+        "@dfinity/agent": "^0.19.3",
+        "@dfinity/identity": "^0.19.3",
+        "@dfinity/principal": "^0.19.3"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.2.tgz",
-      "integrity": "sha512-X2hCqNMhnnmwtnOc0WnymOZYx3qphjEMuSYbBr7tMIkV7Hwt9BmXXlLnQTxUytTPxf+3he0GcS3KzsSQ9CK8ew==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.3.tgz",
+      "integrity": "sha512-yXfbLSWTeRd4G0bLLxYoDqpXH3Jim0P+1PPZOoktXNC1X1hB+ea3yrZebX75t4GVoQK7123F7mxWHiPjuV2tQQ==",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "^0.19.2"
+        "@dfinity/principal": "^0.19.3"
       }
     },
     "node_modules/@dfinity/identity": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.19.2.tgz",
-      "integrity": "sha512-0EwZd8lVfXzHLl5flRysRbjV181b2Xh9loV7QUrt5fE+lP5hgF4f+odFB1YajHQaSyCY1t+v7DA6R9+ICZK9AQ==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.19.3.tgz",
+      "integrity": "sha512-6XHrkNQ8tVN6+MERyXPy+avGHTd2zoX3l47bu6gSwreDdOZQnAnXpHVzLcXhnUptkBVetcC70YQEKCmqtuLriA==",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.3.1",
         "borc": "^2.1.1",
         "tweetnacl": "^1.0.1"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.19.2",
-        "@dfinity/principal": "^0.19.2",
+        "@dfinity/agent": "^0.19.3",
+        "@dfinity/principal": "^0.19.3",
         "@peculiar/webcrypto": "^1.4.0"
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.2.tgz",
-      "integrity": "sha512-vsKN6BKya70bQUsjgKRDlR2lOpv/XpUkCMIiji6rjMtKHIuWEB5Eu3JqZsOuBmWo3A3TT/K/osT9VPm0k4qdYQ==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.3.tgz",
+      "integrity": "sha512-+nixVvdGt7ECxRvLXDXsvU9q9sSPssBtDQ4bXa149SK6gcYcmZ6lfWIi3DJNqj3tGROxILVBsguel9tECappsA==",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.3.1"
       }
@@ -620,14 +637,14 @@
       }
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
-      "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
+      "integrity": "sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==",
       "peer": true,
       "dependencies": {
         "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@peculiar/json-schema": {
@@ -1168,6 +1185,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
       "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+      "peer": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -1189,12 +1207,14 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "peer": true
     },
     "node_modules/bignumber.js": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
       "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -1212,6 +1232,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
       "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+      "peer": true,
       "dependencies": {
         "bignumber.js": "^9.0.0",
         "buffer": "^5.5.0",
@@ -1265,6 +1286,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -1387,7 +1409,8 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "peer": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1466,7 +1489,8 @@
     "node_modules/delimit-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ=="
+      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ==",
+      "peer": true
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -2493,7 +2517,8 @@
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
-      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "peer": true
     },
     "node_modules/idb-keyval": {
       "version": "6.2.1",
@@ -2517,7 +2542,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "peer": true
     },
     "node_modules/ignore": {
       "version": "5.2.4",
@@ -2850,6 +2876,7 @@
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
       "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -2882,6 +2909,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
       "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
+      "peer": true,
       "dependencies": {
         "delimit-stream": "0.1.0"
       }
@@ -3356,6 +3384,7 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
       "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -3545,7 +3574,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "peer": true
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
@@ -3627,7 +3657,8 @@
     "node_modules/simple-cbor": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
-      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w=="
+      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
+      "peer": true
     },
     "node_modules/size-limit": {
       "version": "9.0.0",
@@ -3669,6 +3700,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -3826,7 +3858,8 @@
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3957,7 +3990,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "peer": true
     },
     "node_modules/webcrypto-core": {
       "version": "1.7.7",
@@ -4050,9 +4084,9 @@
       "version": "0.0.34",
       "license": "MIT",
       "peerDependencies": {
-        "@dfinity/agent": "^0.19.2",
-        "@dfinity/identity": "^0.19.2",
-        "@dfinity/principal": "^0.19.2",
+        "@dfinity/agent": "^0.19.3",
+        "@dfinity/identity": "^0.19.3",
+        "@dfinity/principal": "^0.19.3",
         "@junobuild/utils": "*",
         "semver": "7.*"
       }
@@ -4073,24 +4107,13 @@
       "version": "0.0.33",
       "license": "MIT",
       "dependencies": {
-        "@dfinity/agent": "^0.19.2",
-        "@dfinity/auth-client": "^0.19.2",
-        "@dfinity/identity": "^0.19.2",
-        "@dfinity/principal": "^0.19.2",
         "@junobuild/utils": "*"
-      }
-    },
-    "packages/core/node_modules/@dfinity/auth-client": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.19.2.tgz",
-      "integrity": "sha512-aQQ60Y6fuV8849ZzXDwSfJlHO5mWEnzscYVEqveCSDTbRCMw0RV/PKGmbNuM2mIes3ep+LWpq3IQRR56lYZWUA==",
-      "dependencies": {
-        "idb": "^7.0.2"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.19.2",
-        "@dfinity/identity": "^0.19.2",
-        "@dfinity/principal": "^0.19.2"
+        "@dfinity/agent": "^0.19.3",
+        "@dfinity/auth-client": "^0.19.3",
+        "@dfinity/identity": "^0.19.3",
+        "@dfinity/principal": "^0.19.3"
       }
     },
     "packages/ledger": {
@@ -4101,9 +4124,9 @@
         "@noble/hashes": "^1.3.2"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.19.2",
-        "@dfinity/identity": "^0.19.2",
-        "@dfinity/principal": "^0.19.2",
+        "@dfinity/agent": "^0.19.3",
+        "@dfinity/identity": "^0.19.3",
+        "@dfinity/principal": "^0.19.3",
         "@dfinity/utils": "*"
       }
     },
@@ -4121,9 +4144,10 @@
       "dev": true
     },
     "@dfinity/agent": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.2.tgz",
-      "integrity": "sha512-KLRWEjeU9SyyaS7IBVJ9ZUcufxufr55e/kRIyClK157+0pkTG9a8xKjUIMx3QzKvLsqqzXL238nWwdoP6jAD8g==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.3.tgz",
+      "integrity": "sha512-q410aNLoOA1ZkwdAMgSo6t++pjISn9TfSybRXhPRI5Ume7eG6+6qYr/rlvcXy7Nb2+Ar7LTsHNn34IULfjni7w==",
+      "peer": true,
       "requires": {
         "@noble/hashes": "^1.3.1",
         "base64-arraybuffer": "^0.2.0",
@@ -4131,17 +4155,27 @@
         "simple-cbor": "^0.4.1"
       }
     },
+    "@dfinity/auth-client": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.19.3.tgz",
+      "integrity": "sha512-fN5sZXkO3pzsBE+dVOD57Nv59n2H5jtK1JRWP7NEKmxgUk/dOOX6I5ZwUYVOQA3VcJ3azvV9SbXUHSgaFcf0sw==",
+      "peer": true,
+      "requires": {
+        "idb": "^7.0.2"
+      }
+    },
     "@dfinity/candid": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.2.tgz",
-      "integrity": "sha512-X2hCqNMhnnmwtnOc0WnymOZYx3qphjEMuSYbBr7tMIkV7Hwt9BmXXlLnQTxUytTPxf+3he0GcS3KzsSQ9CK8ew==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.3.tgz",
+      "integrity": "sha512-yXfbLSWTeRd4G0bLLxYoDqpXH3Jim0P+1PPZOoktXNC1X1hB+ea3yrZebX75t4GVoQK7123F7mxWHiPjuV2tQQ==",
       "peer": true,
       "requires": {}
     },
     "@dfinity/identity": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.19.2.tgz",
-      "integrity": "sha512-0EwZd8lVfXzHLl5flRysRbjV181b2Xh9loV7QUrt5fE+lP5hgF4f+odFB1YajHQaSyCY1t+v7DA6R9+ICZK9AQ==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.19.3.tgz",
+      "integrity": "sha512-6XHrkNQ8tVN6+MERyXPy+avGHTd2zoX3l47bu6gSwreDdOZQnAnXpHVzLcXhnUptkBVetcC70YQEKCmqtuLriA==",
+      "peer": true,
       "requires": {
         "@noble/hashes": "^1.3.1",
         "borc": "^2.1.1",
@@ -4149,9 +4183,10 @@
       }
     },
     "@dfinity/principal": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.2.tgz",
-      "integrity": "sha512-vsKN6BKya70bQUsjgKRDlR2lOpv/XpUkCMIiji6rjMtKHIuWEB5Eu3JqZsOuBmWo3A3TT/K/osT9VPm0k4qdYQ==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.3.tgz",
+      "integrity": "sha512-+nixVvdGt7ECxRvLXDXsvU9q9sSPssBtDQ4bXa149SK6gcYcmZ6lfWIi3DJNqj3tGROxILVBsguel9tECappsA==",
+      "peer": true,
       "requires": {
         "@noble/hashes": "^1.3.1"
       }
@@ -4404,21 +4439,7 @@
     "@junobuild/core": {
       "version": "file:packages/core",
       "requires": {
-        "@dfinity/agent": "^0.19.2",
-        "@dfinity/auth-client": "^0.19.2",
-        "@dfinity/identity": "^0.19.2",
-        "@dfinity/principal": "^0.19.2",
         "@junobuild/utils": "*"
-      },
-      "dependencies": {
-        "@dfinity/auth-client": {
-          "version": "0.19.2",
-          "resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-0.19.2.tgz",
-          "integrity": "sha512-aQQ60Y6fuV8849ZzXDwSfJlHO5mWEnzscYVEqveCSDTbRCMw0RV/PKGmbNuM2mIes3ep+LWpq3IQRR56lYZWUA==",
-          "requires": {
-            "idb": "^7.0.2"
-          }
-        }
       }
     },
     "@junobuild/ledger": {
@@ -4462,14 +4483,14 @@
       }
     },
     "@peculiar/asn1-schema": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
-      "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
+      "integrity": "sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==",
       "peer": true,
       "requires": {
         "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
       }
     },
     "@peculiar/json-schema": {
@@ -4820,17 +4841,20 @@
     "base64-arraybuffer": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
-      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ=="
+      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+      "peer": true
     },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "peer": true
     },
     "bignumber.js": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
-      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig=="
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "peer": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -4842,6 +4866,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
       "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+      "peer": true,
       "requires": {
         "bignumber.js": "^9.0.0",
         "buffer": "^5.5.0",
@@ -4875,6 +4900,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "peer": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -4967,7 +4993,8 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "peer": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -5026,7 +5053,8 @@
     "delimit-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ=="
+      "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ==",
+      "peer": true
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -5775,7 +5803,8 @@
     "idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
-      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "peer": true
     },
     "idb-keyval": {
       "version": "6.2.1",
@@ -5785,7 +5814,8 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "peer": true
     },
     "ignore": {
       "version": "5.2.4",
@@ -6015,7 +6045,8 @@
     "iso-url": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
+      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+      "peer": true
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -6042,6 +6073,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
       "integrity": "sha512-L3mEegEWHRekSHjc7+sc8eJhba9Clq1PZ8kMkzf8OxElhXc8O4TS5MwcVlj9aEbm5dr81N90WHC5nAz3UO971w==",
+      "peer": true,
       "requires": {
         "delimit-stream": "0.1.0"
       }
@@ -6366,6 +6398,7 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
       "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "peer": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -6483,7 +6516,8 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "peer": true
     },
     "safe-regex-test": {
       "version": "1.0.0",
@@ -6544,7 +6578,8 @@
     "simple-cbor": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
-      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w=="
+      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
+      "peer": true
     },
     "size-limit": {
       "version": "9.0.0",
@@ -6576,6 +6611,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "peer": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -6692,7 +6728,8 @@
     "tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "peer": true
     },
     "type-check": {
       "version": "0.4.0",
@@ -6786,7 +6823,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "peer": true
     },
     "webcrypto-core": {
       "version": "1.7.7",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -39,9 +39,9 @@
   ],
   "homepage": "https://juno.build",
   "peerDependencies": {
-    "@dfinity/agent": "^0.19.2",
-    "@dfinity/identity": "^0.19.2",
-    "@dfinity/principal": "^0.19.2",
+    "@dfinity/agent": "^0.19.3",
+    "@dfinity/identity": "^0.19.3",
+    "@dfinity/principal": "^0.19.3",
     "@junobuild/utils": "*",
     "semver": "7.*"
   }

--- a/packages/core/esbuild.mjs
+++ b/packages/core/esbuild.mjs
@@ -1,11 +1,20 @@
 #!/usr/bin/env node
 
 import esbuild from 'esbuild';
-import {readdirSync, statSync} from 'fs';
+import {readFileSync, readdirSync, statSync} from 'fs';
 import {join} from 'path';
 import {build} from '../../scripts/esbuild.mjs';
 
 build();
+
+// Skip peer dependencies
+const peerDependencies = (packageJson) => {
+  const json = readFileSync(packageJson, 'utf8');
+  const {peerDependencies} = JSON.parse(json);
+  return peerDependencies ?? {};
+};
+
+const workspacePeerDependencies = peerDependencies(join(process.cwd(), 'package.json'));
 
 // Build web workers
 
@@ -27,7 +36,8 @@ const buildWebWorkers = () => {
       bundle: true,
       sourcemap: 'external',
       minify: true,
-      target: ['node18']
+      target: ['node18'],
+      external: [...Object.keys(workspacePeerDependencies)]
     })
     .catch(() => process.exit(1));
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,10 +40,12 @@
   ],
   "homepage": "https://juno.build",
   "dependencies": {
-    "@dfinity/agent": "^0.19.2",
-    "@dfinity/auth-client": "^0.19.2",
-    "@dfinity/identity": "^0.19.2",
-    "@dfinity/principal": "^0.19.2",
     "@junobuild/utils": "*"
+  },
+  "peerDependencies": {
+    "@dfinity/agent": "^0.19.3",
+    "@dfinity/auth-client": "^0.19.3",
+    "@dfinity/identity": "^0.19.3",
+    "@dfinity/principal": "^0.19.3"
   }
 }

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -45,9 +45,9 @@
   ],
   "homepage": "https://juno.build",
   "peerDependencies": {
-    "@dfinity/agent": "^0.19.2",
-    "@dfinity/identity": "^0.19.2",
-    "@dfinity/principal": "^0.19.2",
+    "@dfinity/agent": "^0.19.3",
+    "@dfinity/identity": "^0.19.3",
+    "@dfinity/principal": "^0.19.3",
     "@dfinity/utils": "*"
   },
   "dependencies": {

--- a/scripts/update-agent
+++ b/scripts/update-agent
@@ -9,24 +9,20 @@ function rm_agent() {
 function install_agent() {
   local package=$1
 
-  npm i @dfinity/agent@latest @dfinity/identity@latest @dfinity/principal@latest @dfinity/auth-client@latest --workspace=packages/"$package"
-}
-
-function install_agent_peer() {
-  local package=$1
-
   npm i @dfinity/agent@latest @dfinity/identity@latest @dfinity/principal@latest --workspace=packages/"$package" --save-peer
 }
 
-PACKAGES=core
-PACKAGES_PEER=admin,ledger
+function install_auth_client() {
+  local package=$1
+
+  npm i @dfinity/auth-client@latest --workspace=packages/"$package" --save-peer
+}
+
+PACKAGES=core,admin,ledger
+PACKAGES_AUTH_CLIENT=core
 
 # Remove agent-js libraries from all packages first to avoid resolve conflicts between those
 for package in $(echo $PACKAGES | sed "s/,/ /g"); do
-  rm_agent "$package"
-done
-
-for package in $(echo $PACKAGES_PEER | sed "s/,/ /g"); do
   rm_agent "$package"
 done
 
@@ -34,6 +30,6 @@ for package in $(echo $PACKAGES | sed "s/,/ /g"); do
   install_agent "$package"
 done
 
-for package in $(echo $PACKAGES_PEER | sed "s/,/ /g"); do
-  install_agent_peer "$package"
+for package in $(echo $PACKAGES_AUTH_CLIENT | sed "s/,/ /g"); do
+  install_auth_client "$package"
 done


### PR DESCRIPTION
No other way, it's just impossible to ship a library that contains agent-js to next.js - i.e. agent-js has to be installed by next to be bundled with webpack otherwise the library and app fails in production at runtime.

Fortunately, `npm i` does automatically install peer dependencies. Yarn doesn't though.

Bump agent-js at the same time.