### PR TITLE
feat: cleanup JavaScript Rule type (breaking change)

### DIFF
--- a/packages/admin/src/utils/rule.utils.ts
+++ b/packages/admin/src/utils/rule.utils.ts
@@ -25,20 +25,20 @@ export const mapSetRule = ({
   read,
   write,
   memory,
-  max_size,
-  max_capacity,
-  updated_at,
+  maxSize,
+  maxCapacity,
+  updatedAt,
   mutablePermissions
 }: Pick<
   Rule,
-  'read' | 'write' | 'max_size' | 'max_capacity' | 'updated_at' | 'memory' | 'mutablePermissions'
+  'read' | 'write' | 'maxSize' | 'maxCapacity' | 'updatedAt' | 'memory' | 'mutablePermissions'
 >): SetRule => ({
   read: permissionFromText(read),
   write: permissionFromText(write),
   memory: nonNullish(memory) ? [memoryFromText(memory)] : [],
-  updated_at: isNullish(updated_at) ? [] : [updated_at],
-  max_size: toNullable(nonNullish(max_size) && max_size > 0 ? BigInt(max_size) : undefined),
-  max_capacity: toNullable(nonNullish(max_capacity) && max_capacity > 0 ? max_capacity : undefined),
+  updated_at: isNullish(updatedAt) ? [] : [updatedAt],
+  max_size: toNullable(nonNullish(maxSize) && maxSize > 0 ? BigInt(maxSize) : undefined),
+  max_capacity: toNullable(nonNullish(maxCapacity) && maxCapacity > 0 ? maxCapacity : undefined),
   mutable_permissions: toNullable(mutablePermissions)
 });
 
@@ -54,10 +54,10 @@ export const mapRule = ([collection, rule]: [string, RuleApi]): Rule => {
     read: permissionToText(read),
     write: permissionToText(write),
     memory: memoryToText(fromNullable(memory) ?? MemoryHeap),
-    updated_at,
-    created_at,
-    ...(nonNullish(maxSize) && {max_size: maxSize}),
-    ...(nonNullish(maxCapacity) && {max_capacity: maxCapacity}),
+    updatedAt: updated_at,
+    createdAt: created_at,
+    ...(nonNullish(maxSize) && {maxSize}),
+    ...(nonNullish(maxCapacity) && {maxCapacity}),
     mutablePermissions: fromNullable(mutable_permissions) ?? true
   };
 };
@@ -92,18 +92,18 @@ const permissionFromText = (text: PermissionText): Permission => {
 };
 
 export const memoryFromText = (text: MemoryText): Memory => {
-  switch (text) {
-    case 'Stable':
-      return MemoryStable;
-    default:
+  switch (text.toLowerCase()) {
+    case 'heap':
       return MemoryHeap;
+    default:
+      return MemoryStable;
   }
 };
 
 export const memoryToText = (memory: Memory): MemoryText => {
-  if ('Stable' in memory) {
-    return 'Stable';
+  if ('Heap' in memory) {
+    return 'heap';
   }
 
-  return 'Heap';
+  return 'stable';
 };

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -134,9 +134,9 @@ Configuration options for [Juno] CLI.
 
 #### :gear: SatelliteDevCollection
 
-| Type                     | Type                                       |
-| ------------------------ | ------------------------------------------ |
-| `SatelliteDevCollection` | `Omit<Rule, 'created_at' or 'updated_at'>` |
+| Type                     | Type                                     |
+| ------------------------ | ---------------------------------------- |
+| `SatelliteDevCollection` | `Omit<Rule, 'createdAt' or 'updatedAt'>` |
 
 [:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/config/src/dev/juno.dev.config.ts#L3)
 

--- a/packages/config/src/dev/juno.dev.config.ts
+++ b/packages/config/src/dev/juno.dev.config.ts
@@ -1,6 +1,6 @@
 import type {Rule} from '../types/rules';
 
-export type SatelliteDevCollection = Omit<Rule, 'created_at' | 'updated_at'>;
+export type SatelliteDevCollection = Omit<Rule, 'createdAt' | 'updatedAt'>;
 
 export interface SatelliteDevCollections {
   db?: SatelliteDevCollection[];

--- a/packages/config/src/types/rules.ts
+++ b/packages/config/src/types/rules.ts
@@ -1,5 +1,5 @@
 export type PermissionText = 'public' | 'private' | 'managed' | 'controllers';
-export type MemoryText = 'Heap' | 'Stable';
+export type MemoryText = 'heap' | 'stable';
 export type RulesType = 'db' | 'storage';
 
 export interface Rule {
@@ -7,9 +7,9 @@ export interface Rule {
   read: PermissionText;
   write: PermissionText;
   memory: MemoryText;
-  created_at?: bigint;
-  updated_at?: bigint;
-  max_size?: number;
-  max_capacity?: number;
+  createdAt?: bigint;
+  updatedAt?: bigint;
+  maxSize?: number;
+  maxCapacity?: number;
   mutablePermissions: boolean;
 }


### PR DESCRIPTION
One type has underscore, the other not, one has a capital letter, the other not etc.
Let's be consistent even if it means rolling out a breaking changes (in the lib) once.