### PR TITLE
feat: warning instead of error if analytics worker not initialized

### DIFF
--- a/packages/analytics/src/services/analytics.services.ts
+++ b/packages/analytics/src/services/analytics.services.ts
@@ -5,7 +5,7 @@ import type {IdbPageView} from '../types/idb';
 import type {PostMessageInitEnvData} from '../types/post-message';
 import type {TrackEvent} from '../types/track';
 import {timestamp, userAgent} from '../utils/analytics.utils';
-import {warningNonNullish} from '../utils/log.utils';
+import {warningWorkerNotInitialized} from '../utils/log.utils';
 
 const initSessionId = (): string | undefined => {
   // I faced this issue when I used the library in Docusaurus which does not implement the crypto API when server-side rendering.
@@ -67,8 +67,6 @@ export const initTrackPageViews = (): {cleanup: () => void} => {
   };
 };
 
-const WORKER_UNDEFINED_MSG =
-  'Analytics worker not initialized. Did you call `initOrbiter`?' as const;
 const SESSION_ID_UNDEFINED_MSG = 'No session ID initialized.' as const;
 
 export const setPageView = async () => {
@@ -108,7 +106,7 @@ export const setPageView = async () => {
 };
 
 export const trackPageView = async () => {
-  warningNonNullish(worker, WORKER_UNDEFINED_MSG);
+  warningWorkerNotInitialized(worker);
 
   await setPageView();
 
@@ -121,7 +119,7 @@ export const trackEvent = async (data: TrackEvent) => {
   }
 
   assertNonNullish(sessionId, SESSION_ID_UNDEFINED_MSG);
-  warningNonNullish(worker, WORKER_UNDEFINED_MSG);
+  warningWorkerNotInitialized(worker);
 
   const idb = await import('./idb.services');
   await idb.setTrackEvent({
@@ -133,19 +131,19 @@ export const trackEvent = async (data: TrackEvent) => {
 };
 
 export const initWorkerEnvironment = (env: PostMessageInitEnvData) => {
-  warningNonNullish(worker, WORKER_UNDEFINED_MSG);
+  warningWorkerNotInitialized(worker);
 
   worker?.postMessage({msg: 'junoInitEnvironment', data: env});
 };
 
 export const startTracking = () => {
-  warningNonNullish(worker, WORKER_UNDEFINED_MSG);
+  warningWorkerNotInitialized(worker);
 
   worker?.postMessage({msg: 'junoStartTrackTimer'});
 };
 
 export const stopTracking = () => {
-  warningNonNullish(worker, WORKER_UNDEFINED_MSG);
+  warningWorkerNotInitialized(worker);
 
   worker?.postMessage({msg: 'junoStopTracker'});
 };

--- a/packages/analytics/src/services/analytics.services.ts
+++ b/packages/analytics/src/services/analytics.services.ts
@@ -5,6 +5,7 @@ import type {IdbPageView} from '../types/idb';
 import type {PostMessageInitEnvData} from '../types/post-message';
 import type {TrackEvent} from '../types/track';
 import {timestamp, userAgent} from '../utils/analytics.utils';
+import {warningNonNullish} from '../utils/log.utils';
 
 const initSessionId = (): string | undefined => {
   // I faced this issue when I used the library in Docusaurus which does not implement the crypto API when server-side rendering.
@@ -107,7 +108,7 @@ export const setPageView = async () => {
 };
 
 export const trackPageView = async () => {
-  assertNonNullish(worker, WORKER_UNDEFINED_MSG);
+  warningNonNullish(worker, WORKER_UNDEFINED_MSG);
 
   await setPageView();
 
@@ -120,7 +121,7 @@ export const trackEvent = async (data: TrackEvent) => {
   }
 
   assertNonNullish(sessionId, SESSION_ID_UNDEFINED_MSG);
-  assertNonNullish(worker, WORKER_UNDEFINED_MSG);
+  warningNonNullish(worker, WORKER_UNDEFINED_MSG);
 
   const idb = await import('./idb.services');
   await idb.setTrackEvent({
@@ -132,19 +133,19 @@ export const trackEvent = async (data: TrackEvent) => {
 };
 
 export const initWorkerEnvironment = (env: PostMessageInitEnvData) => {
-  assertNonNullish(worker, WORKER_UNDEFINED_MSG);
+  warningNonNullish(worker, WORKER_UNDEFINED_MSG);
 
   worker?.postMessage({msg: 'junoInitEnvironment', data: env});
 };
 
 export const startTracking = () => {
-  assertNonNullish(worker, WORKER_UNDEFINED_MSG);
+  warningNonNullish(worker, WORKER_UNDEFINED_MSG);
 
   worker?.postMessage({msg: 'junoStartTrackTimer'});
 };
 
 export const stopTracking = () => {
-  assertNonNullish(worker, WORKER_UNDEFINED_MSG);
+  warningNonNullish(worker, WORKER_UNDEFINED_MSG);
 
   worker?.postMessage({msg: 'junoStopTracker'});
 };

--- a/packages/analytics/src/utils/log.utils.ts
+++ b/packages/analytics/src/utils/log.utils.ts
@@ -1,7 +1,10 @@
 import {isNullish} from '@junobuild/utils';
 
-export const warningNonNullish = <T>(value: T, message: string) => {
+const WORKER_UNDEFINED_MSG =
+  'Analytics worker not initialized. Did you call `initOrbiter`?' as const;
+
+export const warningWorkerNotInitialized = <T>(value: T) => {
   if (isNullish(value)) {
-    console.warn(message);
+    console.warn(WORKER_UNDEFINED_MSG);
   }
 };

--- a/packages/analytics/src/utils/log.utils.ts
+++ b/packages/analytics/src/utils/log.utils.ts
@@ -1,0 +1,7 @@
+import {isNullish} from '@junobuild/utils/src';
+
+export const warningNonNullish = <T>(value: T, message: string) => {
+  if (isNullish(value)) {
+    console.warn(message);
+  }
+};

--- a/packages/analytics/src/utils/log.utils.ts
+++ b/packages/analytics/src/utils/log.utils.ts
@@ -1,4 +1,4 @@
-import {isNullish} from '@junobuild/utils/src';
+import {isNullish} from '@junobuild/utils';
 
 export const warningNonNullish = <T>(value: T, message: string) => {
   if (isNullish(value)) {


### PR DESCRIPTION
Resolves #142

To some extension, if there is an error at runtime, not initializing the analytics worker should not block the user. Missing some analytics is less important that breaking user experience.