### PR TITLE
feat: returns also items for listAssets

### DIFF
--- a/packages/core/src/services/storage.services.ts
+++ b/packages/core/src/services/storage.services.ts
@@ -103,41 +103,44 @@ export const listAssets = async ({
 
   const host: string = satelliteUrl(satellite);
 
-  return {
-    assets: items.map(
-      ({
-        key: {full_path, token: t, name, owner, description},
+  const assets = items.map(
+    ({
+      key: {full_path, token: t, name, owner, description},
+      headers,
+      encodings,
+      created_at,
+      updated_at
+    }: AssetNoContent) => {
+      const token = fromNullable(t);
+
+      return {
+        fullPath: full_path,
+        description: fromNullable(description),
+        name,
+        downloadUrl: `${host}${full_path}${token !== undefined ? `?token=${token}` : ''}`,
+        token,
         headers,
-        encodings,
+        encodings: encodings.reduce(
+          (acc, [type, {modified, sha256, total_length}]) => ({
+            ...acc,
+            [type]: {
+              modified,
+              sha256: sha256ToBase64String(sha256),
+              total_length
+            }
+          }),
+          {} as Record<string, AssetEncoding>
+        ),
+        owner: owner.toText(),
         created_at,
         updated_at
-      }: AssetNoContent) => {
-        const token = fromNullable(t);
+      } as Asset;
+    }
+  );
 
-        return {
-          fullPath: full_path,
-          description: fromNullable(description),
-          name,
-          downloadUrl: `${host}${full_path}${token !== undefined ? `?token=${token}` : ''}`,
-          token,
-          headers,
-          encodings: encodings.reduce(
-            (acc, [type, {modified, sha256, total_length}]) => ({
-              ...acc,
-              [type]: {
-                modified,
-                sha256: sha256ToBase64String(sha256),
-                total_length
-              }
-            }),
-            {} as Record<string, AssetEncoding>
-          ),
-          owner: owner.toText(),
-          created_at,
-          updated_at
-        } as Asset;
-      }
-    ),
+  return {
+    items: assets,
+    assets,
     ...rest
   };
 };

--- a/packages/core/src/types/storage.types.ts
+++ b/packages/core/src/types/storage.types.ts
@@ -109,13 +109,15 @@ export interface Asset extends AssetKey {
  * @interface
  * @extends {Pick<ListResults<AssetNoContent>, 'items_length' | 'items_page' | 'matches_length' | 'matches_pages'>}
  */
-export interface Assets
-  extends Pick<
-    ListResults<AssetNoContent>,
-    'items_length' | 'items_page' | 'matches_length' | 'matches_pages'
-  > {
+export interface Assets extends Omit<ListResults<AssetNoContent>, 'items'> {
   /**
    * The collection of assets.
+   * @type {Asset[]}
+   */
+  items: Asset[];
+  /**
+   * The collection of assets. Duplicates items for backwards compatibility. It will ultimately be removed.
+   * @deprecated Use {@link items} instead.
    * @type {Asset[]}
    */
   assets: Asset[];


### PR DESCRIPTION
`listDocs` returns `items` and the website also document `items` for both `listAssets` and `listDocs`, so, let's use `items` for `listAssets` as well.

Backwards compatible.