### PR TITLE
feat: init standalone library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,7 @@ target/
 
 packages/core-peer/declarations
 packages/core-peer/src
+packages/core-standalone/declarations
+packages/core-standalone/src
 
 packages/**/LICENSE

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ JavaScript libraries for interfacing with [Juno].
 ## Libraries
 
 - [core](/packages/core): core client library
+- [core-standalone](/packages/core-standalone): a synchronized copy of [core](/packages/core) with all dependencies bundled — no peer dependencies
 - [analytics](/packages/analytics): tracker for analytics
 - [admin](/packages/admin): interfacing with admin features
 - [config](/packages/config): configuration options for the CLI
@@ -12,7 +13,6 @@ JavaScript libraries for interfacing with [Juno].
 - [cli-tools](/packages/cli-tools): few tools used in Juno's CLIs and Plugins
 - [did-tools](/packages/cli-tools): tools for generating APIs from DID files
 - [config-loader](/packages/config-loader): utilities for reading configuration settings
-- [core-peer](/packages/core-peer): a synchronized copy of [core](/packages/core) for the bundlers that requires polyfilling DFINITY `agent-js` themselves
 - [console](/packages/console): interfacing with Junos' Console
 - [storage](/packages/storage): interfacing with Junos' Storage features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "packages/cli-tools",
         "packages/did-tools",
         "packages/config-loader",
-        "packages/console"
+        "packages/console",
+        "packages/core-standalone"
       ],
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
@@ -1451,6 +1452,10 @@
     },
     "node_modules/@junobuild/core-peer": {
       "resolved": "packages/core-peer",
+      "link": true
+    },
+    "node_modules/@junobuild/core-standalone": {
+      "resolved": "packages/core-standalone",
       "link": true
     },
     "node_modules/@junobuild/did-tools": {
@@ -9285,6 +9290,20 @@
         "@dfinity/principal": "^2.1.3"
       }
     },
+    "packages/core-standalone": {
+      "name": "@junobuild/core-standalone",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@dfinity/agent": "^2.1.3",
+        "@dfinity/auth-client": "^2.1.3",
+        "@dfinity/candid": "^2.1.3",
+        "@dfinity/identity": "^2.1.3",
+        "@dfinity/principal": "^2.1.3",
+        "@junobuild/storage": "*",
+        "@junobuild/utils": "*"
+      }
+    },
     "packages/did-tools": {
       "name": "@junobuild/did-tools",
       "version": "0.0.4",
@@ -10194,6 +10213,18 @@
     "@junobuild/core-peer": {
       "version": "file:packages/core-peer",
       "requires": {
+        "@junobuild/storage": "*",
+        "@junobuild/utils": "*"
+      }
+    },
+    "@junobuild/core-standalone": {
+      "version": "file:packages/core-standalone",
+      "requires": {
+        "@dfinity/agent": "^2.1.3",
+        "@dfinity/auth-client": "^2.1.3",
+        "@dfinity/candid": "^2.1.3",
+        "@dfinity/identity": "^2.1.3",
+        "@dfinity/principal": "^2.1.3",
         "@junobuild/storage": "*",
         "@junobuild/utils": "*"
       }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,17 @@
       ]
     },
     {
+      "name": "@junobuild/core-standalone",
+      "path": "./packages/core-standalone/dist/index.js",
+      "limit": "10 kB",
+      "ignore": [
+        "@dfinity/agent",
+        "@dfinity/candid",
+        "@dfinity/principal",
+        "@dfinity/auth-client"
+      ]
+    },
+    {
       "name": "@junobuild/utils",
       "path": "./packages/utils/dist/index.js",
       "limit": "1 kB",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "packages/admin",
     "packages/analytics",
     "packages/core-peer",
+    "packages/core-standalone",
     "packages/cli-tools",
     "packages/did-tools",
     "packages/config-loader",

--- a/package.json
+++ b/package.json
@@ -84,13 +84,7 @@
     {
       "name": "@junobuild/core-standalone",
       "path": "./packages/core-standalone/dist/index.js",
-      "limit": "10 kB",
-      "ignore": [
-        "@dfinity/agent",
-        "@dfinity/candid",
-        "@dfinity/principal",
-        "@dfinity/auth-client"
-      ]
+      "limit": "85 kB"
     },
     {
       "name": "@junobuild/utils",

--- a/packages/core-standalone/README.md
+++ b/packages/core-standalone/README.md
@@ -1,0 +1,17 @@
+[![npm][npm-badge]][npm-badge-url]
+[![license][npm-license]][npm-license-url]
+
+[npm-badge]: https://img.shields.io/npm/v/@junobuild/core-standalone
+[npm-badge-url]: https://www.npmjs.com/package/@junobuild/core-standalone
+[npm-license]: https://img.shields.io/npm/l/@junobuild/core-standalone
+[npm-license-url]: https://github.com/junobuild/juno-js/blob/main/LICENSE
+
+# Juno JavaScript core SDK
+
+JavaScript [core](../core/README.md) client for Juno with all dependencies bundled — no peer dependencies.
+
+## License
+
+MIT © [David Dal Busco](mailto:david.dalbusco@outlook.com)
+
+[juno]: https://juno.build

--- a/packages/core-standalone/esbuild.mjs
+++ b/packages/core-standalone/esbuild.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import esbuild from 'esbuild';
+import {readdirSync, statSync} from 'fs';
+import {join} from 'path';
+import {build} from '../../scripts/esbuild.mjs';
+
+build();
+
+// Build web workers
+
+const buildWebWorkers = () => {
+  const entryPoints = readdirSync(join(process.cwd(), 'src', 'workers'))
+    .filter(
+      (file) =>
+        !file.includes('test') &&
+        !file.includes('spec') &&
+        !file.endsWith('.swp') &&
+        statSync(join(process.cwd(), 'src', 'workers', file)).isFile()
+    )
+    .map((file) => `src/workers/${file}`);
+
+  esbuild
+    .build({
+      entryPoints,
+      outdir: 'dist/workers',
+      bundle: true,
+      sourcemap: 'external',
+      minify: true,
+      target: ['node18']
+    })
+    .catch(() => process.exit(1));
+};
+
+buildWebWorkers();

--- a/packages/core-standalone/package.json
+++ b/packages/core-standalone/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@junobuild/core-standalone",
+  "version": "0.0.1",
+  "description": "JavaScript core client for Juno with all dependencies bundled — no peer dependencies",
+  "author": "David Dal Busco (https://daviddalbusco.com)",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/node/index.mjs",
+  "module": "./dist/browser/index.js",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/browser/index.js"
+      },
+      "require": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/node/index.mjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "rmdir": "node ../../scripts/rmdir.mjs",
+    "ts-declaration": "tsc --emitDeclarationOnly --outDir dist/types",
+    "copy-src": "rm -rf src && cp -R ../core/src .",
+    "copy-declarations": "rm -rf declarations && cp -R ../core/declarations .",
+    "copy": "npm run copy-src && npm run copy-declarations",
+    "build": "npm run rmdir && mkdir -p dist && npm run copy && cp -R declarations dist && node esbuild.mjs && npm run ts-declaration",
+    "prepack": "npm run build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/junobuild/juno-js.git",
+    "directory": "packages/core-standanlone"
+  },
+  "bugs": {
+    "url": "https://github.com/junobuild/juno-js"
+  },
+  "keywords": [
+    "blockchain-as-a-service",
+    "baas",
+    "dapps",
+    "dapps-development",
+    "internet computer",
+    "smart-contracts",
+    "web3"
+  ],
+  "homepage": "https://juno.build",
+  "dependencies": {
+    "@dfinity/agent": "^2.1.3",
+    "@dfinity/auth-client": "^2.1.3",
+    "@dfinity/candid": "^2.1.3",
+    "@dfinity/identity": "^2.1.3",
+    "@dfinity/principal": "^2.1.3",
+    "@junobuild/storage": "*",
+    "@junobuild/utils": "*"
+  }
+}

--- a/packages/core-standalone/tsconfig.json
+++ b/packages/core-standalone/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "candid/**/*"]
+}

--- a/scripts/build-next
+++ b/scripts/build-next
@@ -13,6 +13,7 @@ node ./scripts/update-version.mjs admin
 node ./scripts/update-version.mjs analytics
 node ./scripts/update-version.mjs console
 node ./scripts/update-version.mjs core-peer
+node ./scripts/update-version.mjs core-standalone
 
 : Now we can build
 npm run build --workspaces

--- a/scripts/license.sh
+++ b/scripts/license.sh
@@ -8,7 +8,7 @@ function copy_license() {
   cp LICENSE packages/"$lib"
 }
 
-LIBS=utils,config,storage,core,admin,console,analytics,core-peer,cli-tools,did-tools,config-loader
+LIBS=utils,config,storage,core,admin,console,analytics,core-peer,core-standalone,cli-tools,did-tools,config-loader
 
 for lib in $(echo $LIBS | sed "s/,/ /g"); do
   copy_license "$lib"

--- a/scripts/publish-npm-next.sh
+++ b/scripts/publish-npm-next.sh
@@ -7,7 +7,7 @@ function publish_npm() {
 }
 
 # Tips: libs use by other libs first
-LIBS=utils,config,config-loader,cli-tools,did-tools,storage,core,admin,console,analytics,core-peer
+LIBS=utils,config,config-loader,cli-tools,did-tools,storage,core,admin,console,analytics,core-peer,core-standalone
 
 for lib in $(echo $LIBS | sed "s/,/ /g"); do
   publish_npm "$lib"

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -18,7 +18,7 @@ function publish_npm() {
 }
 
 # Tips: libs use by other libs first
-LIBS=utils,config,config-loader,cli-tools,did-tools,storage,core,admin,console,analytics,core-peer
+LIBS=utils,config,config-loader,cli-tools,did-tools,storage,core,admin,console,analytics,core-peer,core-standalone
 
 for lib in $(echo $LIBS | sed "s/,/ /g"); do
   publish_npm "$lib"

--- a/scripts/update-agent
+++ b/scripts/update-agent
@@ -30,7 +30,7 @@ function install_principal_peer() {
   npm i @dfinity/principal@latest --workspace=packages/"$package" --save-peer
 }
 
-PACKAGES=core
+PACKAGES=core,core-standalone
 PACKAGES_PEER=admin,console,storage,core-peer
 PACKAGES_AUTH_CLIENT_PEER=core-peer
 PACKAGES_PEER_UTILS=utils


### PR DESCRIPTION
We gonna shift the approach by making `@junobuild/core` using agent-js with peer dependencies, deprecate `@junobuild/core-peer` and introduce `@junobuild/core-standalone` with everything included.