### PR TITLE
feat: core use agent-js as peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,11 @@
         "packages/admin",
         "packages/analytics",
         "packages/core-peer",
+        "packages/core-standalone",
         "packages/cli-tools",
         "packages/did-tools",
         "packages/config-loader",
-        "packages/console",
-        "packages/core-standalone"
+        "packages/console"
       ],
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
@@ -9265,13 +9265,14 @@
       "version": "0.0.63",
       "license": "MIT",
       "dependencies": {
-        "@dfinity/agent": "^2.1.3",
-        "@dfinity/auth-client": "^2.1.3",
-        "@dfinity/candid": "^2.1.3",
-        "@dfinity/identity": "^2.1.3",
-        "@dfinity/principal": "^2.1.3",
         "@junobuild/storage": "*",
         "@junobuild/utils": "*"
+      },
+      "peerDependencies": {
+        "@dfinity/agent": "^2.1.3",
+        "@dfinity/candid": "^2.1.3",
+        "@dfinity/identity": "^2.1.3",
+        "@dfinity/principal": "^2.1.3"
       }
     },
     "packages/core-peer": {
@@ -10201,11 +10202,6 @@
     "@junobuild/core": {
       "version": "file:packages/core",
       "requires": {
-        "@dfinity/agent": "^2.1.3",
-        "@dfinity/auth-client": "^2.1.3",
-        "@dfinity/candid": "^2.1.3",
-        "@dfinity/identity": "^2.1.3",
-        "@dfinity/principal": "^2.1.3",
         "@junobuild/storage": "*",
         "@junobuild/utils": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9270,6 +9270,7 @@
       },
       "peerDependencies": {
         "@dfinity/agent": "^2.1.3",
+        "@dfinity/auth-client": "^2.1.3",
         "@dfinity/candid": "^2.1.3",
         "@dfinity/identity": "^2.1.3",
         "@dfinity/principal": "^2.1.3"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,13 @@
     {
       "name": "@junobuild/core",
       "path": "./packages/core/dist/index.js",
-      "limit": "85 kB"
+      "limit": "10 kB",
+      "ignore": [
+        "@dfinity/agent",
+        "@dfinity/candid",
+        "@dfinity/principal",
+        "@dfinity/auth-client"
+      ]
     },
     {
       "name": "@junobuild/core-worker",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,12 +50,13 @@
   ],
   "homepage": "https://juno.build",
   "dependencies": {
-    "@dfinity/agent": "^2.1.3",
-    "@dfinity/auth-client": "^2.1.3",
-    "@dfinity/candid": "^2.1.3",
-    "@dfinity/identity": "^2.1.3",
-    "@dfinity/principal": "^2.1.3",
     "@junobuild/storage": "*",
     "@junobuild/utils": "*"
+  },
+  "peerDependencies": {
+    "@dfinity/agent": "^2.1.3",
+    "@dfinity/candid": "^2.1.3",
+    "@dfinity/identity": "^2.1.3",
+    "@dfinity/principal": "^2.1.3"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,6 +55,7 @@
   },
   "peerDependencies": {
     "@dfinity/agent": "^2.1.3",
+    "@dfinity/auth-client": "^2.1.3",
     "@dfinity/candid": "^2.1.3",
     "@dfinity/identity": "^2.1.3",
     "@dfinity/principal": "^2.1.3"

--- a/scripts/update-agent
+++ b/scripts/update-agent
@@ -30,8 +30,8 @@ function install_principal_peer() {
   npm i @dfinity/principal@latest --workspace=packages/"$package" --save-peer
 }
 
-PACKAGES=core,core-standalone
-PACKAGES_PEER=admin,console,storage,core-peer
+PACKAGES=core-standalone
+PACKAGES_PEER=admin,console,storage,core,core-peer
 PACKAGES_AUTH_CLIENT_PEER=core-peer
 PACKAGES_PEER_UTILS=utils
 

--- a/scripts/update-agent
+++ b/scripts/update-agent
@@ -32,7 +32,7 @@ function install_principal_peer() {
 
 PACKAGES=core-standalone
 PACKAGES_PEER=admin,console,storage,core,core-peer
-PACKAGES_AUTH_CLIENT_PEER=core-peer
+PACKAGES_AUTH_CLIENT_PEER=core,core-peer
 PACKAGES_PEER_UTILS=utils
 
 # Remove agent-js libraries from all packages first to avoid resolve conflicts between those


### PR DESCRIPTION
We want to ease the onboarding and also resolve the confusion about when peer and when not peer. So we are going to use peer dependencies per default, handle this in the doc and provide a standalone package.