### PR TITLE
chore: version v0.1.0 for core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@junobuild/juno-js",
-  "version": "0.0.97",
+  "version": "0.0.98",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@junobuild/juno-js",
-      "version": "0.0.97",
+      "version": "0.0.98",
       "license": "MIT",
       "workspaces": [
         "packages/utils",
@@ -9262,7 +9262,7 @@
     },
     "packages/core": {
       "name": "@junobuild/core",
-      "version": "0.0.63",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@junobuild/storage": "*",
@@ -9278,7 +9278,7 @@
     },
     "packages/core-peer": {
       "name": "@junobuild/core-peer",
-      "version": "0.0.29",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@junobuild/storage": "*",
@@ -9294,7 +9294,7 @@
     },
     "packages/core-standalone": {
       "name": "@junobuild/core-standalone",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@dfinity/agent": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/juno-js",
-  "version": "0.0.97",
+  "version": "0.0.98",
   "description": "JavaScript libraries for interfacing with Juno",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",

--- a/packages/core-peer/package.json
+++ b/packages/core-peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/core-peer",
-  "version": "0.0.29",
+  "version": "0.1.0",
   "description": "JavaScript core client for Juno minus DFINITY agent-js dependencies",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",

--- a/packages/core-standalone/package.json
+++ b/packages/core-standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/core-standalone",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "JavaScript core client for Juno with all dependencies bundled — no peer dependencies",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junobuild/core",
-  "version": "0.0.63",
+  "version": "0.1.0",
   "description": "JavaScript core client for Juno",
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",


### PR DESCRIPTION
We want to improve a bit semver by starting using v0.x.y.

x for breaking changes.