### PR TITLE
feat: did-tools adapt for peer and standalone core

### DIFF
--- a/packages/did-tools/src/tests/services/parser.services.spec.ts
+++ b/packages/did-tools/src/tests/services/parser.services.spec.ts
@@ -27,18 +27,18 @@ describe('parser-services', () => {
     expect(result.trim()).toEqual(mockTransformedCoreJS);
   });
 
-  it('should import from core-peer', () => {
+  it('should import from core-standalone', () => {
     const result = parseApi({
       methods: mockMethodSignatures,
       imports: [],
       transformerOptions: {
         outputLanguage: 'ts',
-        coreLib: 'core-peer'
+        coreLib: 'core-standalone'
       }
     });
 
     expect(result.trim()).toContain(
-      "import {getSatelliteExtendedActor} from '@junobuild/core-peer';"
+      "import {getSatelliteExtendedActor} from '@junobuild/core-standalone';"
     );
   });
 

--- a/packages/did-tools/src/types/transformer-options.ts
+++ b/packages/did-tools/src/types/transformer-options.ts
@@ -1,4 +1,4 @@
 export interface TransformerOptions {
   outputLanguage: 'js' | 'ts';
-  coreLib?: 'core' | 'core-peer';
+  coreLib?: 'core' | 'core-standalone';
 }


### PR DESCRIPTION
`core-peer` as been deprecated in https://github.com/junobuild/juno-js/releases/tag/v0.0.98

There is a new optional `core-standalone`.