### PR TITLE
feat: SignInInitError when authclient not initialized

### DIFF
--- a/packages/core/src/services/auth.services.ts
+++ b/packages/core/src/services/auth.services.ts
@@ -10,7 +10,7 @@ import {ActorStore} from '../stores/actor.store';
 import {AgentStore} from '../stores/agent.store';
 import {AuthStore} from '../stores/auth.store';
 import type {Provider, SignInOptions} from '../types/auth.types';
-import {SignInError, SignInUserInterruptError} from '../types/errors.types';
+import {SignInError, SignInInitError, SignInUserInterruptError} from '../types/errors.types';
 import {createAuthClient} from '../utils/auth.utils';
 import {initUser} from './user.services';
 
@@ -42,7 +42,7 @@ export const signIn = (options?: SignInOptions): Promise<void> =>
   new Promise<void>(async (resolve, reject) => {
     if (isNullish(authClient)) {
       reject(
-        new SignInError(
+        new SignInInitError(
           'No client is ready to perform a sign-in. Have you initialized the Satellite?'
         )
       );

--- a/packages/core/src/types/errors.types.ts
+++ b/packages/core/src/types/errors.types.ts
@@ -1,5 +1,5 @@
 export class SignInError extends Error {}
-
+export class SignInInitError extends Error {}
 export class SignInUserInterruptError extends Error {}
 
 export class InitError extends Error {}


### PR DESCRIPTION
It's a bit cleaner to have a specific error type for this edge case