### PR TITLE
feat: retry get user on sign-in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "workspaces": [
         "packages/utils",
+        "packages/errors",
         "packages/config",
         "packages/storage",
         "packages/core",
@@ -20,8 +21,7 @@
         "packages/cli-tools",
         "packages/did-tools",
         "packages/config-loader",
-        "packages/console",
-        "packages/errors"
+        "packages/console"
       ],
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
@@ -10450,6 +10450,7 @@
       "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
+        "@junobuild/errors": "*",
         "@junobuild/storage": "*",
         "@junobuild/utils": "*"
       },
@@ -10511,8 +10512,7 @@
     "packages/errors": {
       "name": "@junobuild/errors",
       "version": "0.0.1",
-      "license": "MIT",
-      "devDependencies": {}
+      "license": "MIT"
     },
     "packages/storage": {
       "name": "@junobuild/storage",
@@ -11453,6 +11453,7 @@
     "@junobuild/core": {
       "version": "file:packages/core",
       "requires": {
+        "@junobuild/errors": "*",
         "@junobuild/storage": "*",
         "@junobuild/utils": "*"
       }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,7 @@
   ],
   "homepage": "https://juno.build",
   "dependencies": {
+    "@junobuild/errors": "*",
     "@junobuild/storage": "*",
     "@junobuild/utils": "*"
   },

--- a/packages/core/src/services/user.services.ts
+++ b/packages/core/src/services/user.services.ts
@@ -1,6 +1,6 @@
 import type {Identity} from '@dfinity/agent';
 import {isNullish, nonNullish} from '@dfinity/utils';
-import {isSatelliteError, JUNO_DATASTORE_ERROR_USER_CANNOT_UPDATE} from '@junobuild/errors/src';
+import {isSatelliteError, JUNO_DATASTORE_ERROR_USER_CANNOT_UPDATE} from '@junobuild/errors';
 import type {Provider, User, UserData} from '../types/auth.types';
 import {InitError} from '../types/errors.types';
 import {getIdentity} from './auth.services';

--- a/packages/core/src/services/user.services.ts
+++ b/packages/core/src/services/user.services.ts
@@ -21,34 +21,31 @@ export const initUser = async (provider?: Provider): Promise<User> => {
       key: userId
     });
 
-  // TODO: uncomment
-  const user = undefined; // await loadUser();
+  const user = await loadUser();
 
-  if (isNullish(user)) {
-    try {
-      return await createUser({userId, provider});
-    } catch (error: unknown) {
-      console.log('----->', error);
-
-      // When a user signs in for the first time and get user returns `undefined`,
-      // a new user entry is created. If the browser is reloaded and get user
-      // still returns `undefined`, another try is made to create user entry, which is not
-      // allowed since only the controller can update users, assuming the entry has been
-      // created in the meantime. To prevent errors, we reload the user data,
-      // as the issue indicates the user entity exists.
-      if (isSatelliteError({error, type: JUNO_DATASTORE_ERROR_USER_CANNOT_UPDATE})) {
-        const userOnCreateError = await loadUser();
-
-        if (nonNullish(userOnCreateError)) {
-          return userOnCreateError;
-        }
-      }
-
-      throw error;
-    }
+  if (nonNullish(user)) {
+    return user;
   }
 
-  return user;
+  try {
+    return await createUser({userId, provider});
+  } catch (error: unknown) {
+    // When a user signs in for the first time and get user returns `undefined`,
+    // a new user entry is created. If the browser is reloaded and get user
+    // still returns `undefined`, another try is made to create user entry, which is not
+    // allowed since only the controller can update users, assuming the entry has been
+    // created in the meantime. To prevent errors, we reload the user data,
+    // as the issue indicates the user entity exists.
+    if (isSatelliteError({error, type: JUNO_DATASTORE_ERROR_USER_CANNOT_UPDATE})) {
+      const userOnCreateError = await loadUser();
+
+      if (nonNullish(userOnCreateError)) {
+        return userOnCreateError;
+      }
+    }
+
+    throw error;
+  }
 };
 
 const createUser = ({

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -1,1 +1,2 @@
 export * from './constants';
+export * from './utils';

--- a/packages/errors/src/utils.ts
+++ b/packages/errors/src/utils.ts
@@ -1,0 +1,11 @@
+export const isSatelliteError = ({error, type}: {error: unknown; type: string}): boolean => {
+  if (typeof error === 'string') {
+    return error.includes(type);
+  }
+
+  if (error instanceof Error) {
+    return error.message.includes(type);
+  }
+
+  return false;
+};


### PR DESCRIPTION
See comment in code. This is meant to prevent an edge case given that has of next version of the Satellite, users cannot update their entity anymore.