### PR TITLE
fix: missing types for junobuild/errors

### DIFF
--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -27,7 +27,8 @@
   ],
   "scripts": {
     "rmdir": "node ../../scripts/rmdir.mjs",
-    "build": "npm run rmdir && mkdir -p dist && node esbuild.mjs",
+    "ts-declaration": "tsc --emitDeclarationOnly --outDir dist/types",
+    "build": "npm run rmdir && mkdir -p dist && node esbuild.mjs && npm run ts-declaration",
     "prepack": "npm run build"
   },
   "repository": {


### PR DESCRIPTION
As discovered in https://github.com/junobuild/juno/pull/1264 the types are missing in the new library