### PR TITLE
build: functions as multi-entry library

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     },
     {
       "name": "@junobuild/functions",
-      "path": "./packages/functions/dist/index.js",
+      "path": "./packages/functions/index.js",
       "limit": "5 kB",
       "ignore": [
         "@dfinity/utils",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "size": "size-limit --json",
     "update:agent": "./scripts/update-agent",
     "docs": "node scripts/docs.js && prettier --write packages/**/README.md",
-    "test": "vitest"
+    "test": "vitest",
+    "clean": "npm run clean --workspaces --if-present"
   },
   "workspaces": [
     "packages/utils",

--- a/packages/functions/.gitignore
+++ b/packages/functions/.gitignore
@@ -1,0 +1,9 @@
+# Ignore everything
+*
+
+# Except
+!src/
+!esbuild.mjs
+!package.json
+!README.md
+!tsconfig.json

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -23,9 +23,9 @@
     "**/*.d.ts.map"
   ],
   "scripts": {
-    "rmdir": "node ../../scripts/rmdir.mjs",
-    "ts-declaration": "tsc --emitDeclarationOnly --outDir dist && cp -R src/*.d.ts dist/",
-    "build": "npm run rmdir && mkdir -p dist && tsc --noEmit && node esbuild.mjs && npm run ts-declaration",
+    "clean": "git ls-files --others --ignored --exclude-standard | grep -v \"LICENSE\" | xargs rm -rf",
+    "ts-declaration": "tsc --emitDeclarationOnly -outDir . && cp -R src/*.d.ts ./",
+    "build": "npm run clean && tsc --noEmit && node esbuild.mjs && npm run ts-declaration",
     "prepack": "npm run build"
   },
   "repository": {

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -5,26 +5,27 @@
   "author": "David Dal Busco (https://daviddalbusco.com)",
   "license": "MIT",
   "type": "module",
-  "main": "./dist/browser/index.js",
-  "module": "./dist/browser/index.js",
-  "types": "./dist/types/index.d.ts",
+  "main": "index.js",
+  "module": "index.js",
+  "types": "index.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/types/index.d.ts",
-        "default": "./dist/browser/index.js"
-      }
+      "types": "./index.d.ts",
+      "import": "./index.js"
     }
   },
   "files": [
-    "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "**/*.js",
+    "**/*.js.map",
+    "**/*.d.ts",
+    "**/*.d.ts.map"
   ],
   "scripts": {
     "rmdir": "node ../../scripts/rmdir.mjs",
-    "ts-declaration": "tsc --emitDeclarationOnly --outDir dist/types && cp -R src/*.d.ts dist/types/",
-    "build": "npm run rmdir && mkdir -p dist && node esbuild.mjs && npm run ts-declaration",
+    "ts-declaration": "tsc --emitDeclarationOnly --outDir dist && cp -R src/*.d.ts dist/",
+    "build": "npm run rmdir && mkdir -p dist && tsc --noEmit && node esbuild.mjs && npm run ts-declaration",
     "prepack": "npm run build"
   },
   "repository": {

--- a/scripts/esbuild-functions.mjs
+++ b/scripts/esbuild-functions.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import esbuild from 'esbuild';
-import {copyPackageJsonFiles, externalPeerDependencies} from './esbuild-pkg.mjs';
-import {collectEntryPoints, createDistFolder, DIST} from './esbuild-utils.mjs';
+import {externalPeerDependencies} from './esbuild-pkg.mjs';
+import {collectEntryPoints} from './esbuild-utils.mjs';
 
 const build = () => {
   const entryPoints = collectEntryPoints();
@@ -10,7 +10,7 @@ const build = () => {
   esbuild
     .build({
       entryPoints,
-      outdir: DIST,
+      outdir: process.cwd(),
       bundle: true,
       sourcemap: true,
       minify: true,
@@ -33,7 +33,5 @@ const build = () => {
 };
 
 export const buildFunctions = () => {
-  createDistFolder();
-  copyPackageJsonFiles();
   build();
 };

--- a/scripts/esbuild-functions.mjs
+++ b/scripts/esbuild-functions.mjs
@@ -1,14 +1,16 @@
-import esbuild from 'esbuild';
-import {join} from 'path';
-import {createDistFolder, DIST, workspacePeerDependencies, writeEntries} from './esbuild-utils.mjs';
+#!/usr/bin/env node
 
-export const buildFunctions = () => {
-  createDistFolder();
+import esbuild from 'esbuild';
+import {copyPackageJsonFiles, externalPeerDependencies} from './esbuild-pkg.mjs';
+import {collectEntryPoints, createDistFolder, DIST} from './esbuild-utils.mjs';
+
+const build = () => {
+  const entryPoints = collectEntryPoints();
 
   esbuild
     .build({
-      entryPoints: ['src/index.ts'],
-      outdir: join(DIST, 'browser'),
+      entryPoints,
+      outdir: DIST,
       bundle: true,
       sourcemap: true,
       minify: true,
@@ -25,9 +27,13 @@ export const buildFunctions = () => {
       define: {
         self: 'globalThis'
       },
-      external: [...Object.keys(workspacePeerDependencies)]
+      external: externalPeerDependencies
     })
     .catch(() => process.exit(1));
 };
 
-writeEntries();
+export const buildFunctions = () => {
+  createDistFolder();
+  copyPackageJsonFiles();
+  build();
+};

--- a/scripts/esbuild-pkg.mjs
+++ b/scripts/esbuild-pkg.mjs
@@ -1,0 +1,27 @@
+import {copyFileSync, readFileSync} from 'node:fs';
+import {join} from 'path';
+import {DIST} from './esbuild-utils.mjs';
+
+export const PACKAGE_JSON = 'package.json';
+
+const readPackageJson = () => {
+  const packageJson = join(process.cwd(), PACKAGE_JSON);
+  const json = readFileSync(packageJson, 'utf8');
+  const {peerDependencies, files} = JSON.parse(json);
+  return {
+    workspacePeerDependencies: peerDependencies ?? {},
+    packageJsonFiles: files ?? []
+  };
+};
+
+const {workspacePeerDependencies, packageJsonFiles} = readPackageJson();
+
+export const externalPeerDependencies = [...Object.keys(workspacePeerDependencies)];
+
+export const copyPackageJsonFiles = () => {
+  const copyFile = (filename) => copyFileSync(join(process.cwd(), filename), join(DIST, filename));
+
+  packageJsonFiles.filter((entry) => !entry.includes('*')).forEach(copyFile);
+
+  copyFile(PACKAGE_JSON);
+};

--- a/scripts/esbuild-pkg.mjs
+++ b/scripts/esbuild-pkg.mjs
@@ -1,6 +1,5 @@
-import {copyFileSync, readFileSync} from 'node:fs';
+import {readFileSync} from 'node:fs';
 import {join} from 'path';
-import {DIST} from './esbuild-utils.mjs';
 
 export const PACKAGE_JSON = 'package.json';
 
@@ -9,19 +8,10 @@ const readPackageJson = () => {
   const json = readFileSync(packageJson, 'utf8');
   const {peerDependencies, files} = JSON.parse(json);
   return {
-    workspacePeerDependencies: peerDependencies ?? {},
-    packageJsonFiles: files ?? []
+    workspacePeerDependencies: peerDependencies ?? {}
   };
 };
 
-const {workspacePeerDependencies, packageJsonFiles} = readPackageJson();
+const {workspacePeerDependencies} = readPackageJson();
 
 export const externalPeerDependencies = [...Object.keys(workspacePeerDependencies)];
-
-export const copyPackageJsonFiles = () => {
-  const copyFile = (filename) => copyFileSync(join(process.cwd(), filename), join(DIST, filename));
-
-  packageJsonFiles.filter((entry) => !entry.includes('*')).forEach(copyFile);
-
-  copyFile(PACKAGE_JSON);
-};

--- a/scripts/esbuild-utils.mjs
+++ b/scripts/esbuild-utils.mjs
@@ -16,14 +16,14 @@ export const writeEntries = () => {
 
 export const collectEntryPoints = () => {
   return readdirSync(join(process.cwd(), 'src'))
-      .filter(
-          (file) =>
-              !file.includes('test') &&
-              !file.includes('spec') &&
-              !file.includes('mock') &&
-              !file.endsWith('.swp') &&
-              !file.endsWith('.worker.ts') &&
-              statSync(join(process.cwd(), 'src', file)).isFile()
-      )
-      .map((file) => `src/${file}`);
-}
+    .filter(
+      (file) =>
+        !file.includes('test') &&
+        !file.includes('spec') &&
+        !file.includes('mock') &&
+        !file.endsWith('.swp') &&
+        !file.endsWith('.worker.ts') &&
+        statSync(join(process.cwd(), 'src', file)).isFile()
+    )
+    .map((file) => `src/${file}`);
+};

--- a/scripts/esbuild-utils.mjs
+++ b/scripts/esbuild-utils.mjs
@@ -1,5 +1,4 @@
-import {existsSync, mkdirSync, writeFileSync} from 'fs';
-import {readFileSync} from 'node:fs';
+import {existsSync, mkdirSync, readdirSync, statSync, writeFileSync} from 'fs';
 import {join} from 'path';
 
 export const DIST = join(process.cwd(), 'dist');
@@ -15,11 +14,16 @@ export const writeEntries = () => {
   writeFileSync(join(DIST, 'index.js'), "export * from './browser/index.js';");
 };
 
-// Skip peer dependencies
-const peerDependencies = (packageJson) => {
-  const json = readFileSync(packageJson, 'utf8');
-  const {peerDependencies} = JSON.parse(json);
-  return peerDependencies ?? {};
-};
-
-export const workspacePeerDependencies = peerDependencies(join(process.cwd(), 'package.json'));
+export const collectEntryPoints = () => {
+  return readdirSync(join(process.cwd(), 'src'))
+      .filter(
+          (file) =>
+              !file.includes('test') &&
+              !file.includes('spec') &&
+              !file.includes('mock') &&
+              !file.endsWith('.swp') &&
+              !file.endsWith('.worker.ts') &&
+              statSync(join(process.cwd(), 'src', file)).isFile()
+      )
+      .map((file) => `src/${file}`);
+}


### PR DESCRIPTION
I want to ship the functions library as a multi-entry library (B.), kind of feel like it's cooler and more modern.

```
// A.
import { icCdkId, setDocStore } from '@junobuild/functions';

console.log(icCdkId());

// B.
import { setDocStore } from '@junobuild/functions/sdk';
import { id } from '@junobuild/functions/ic-cdk';

console.log(id());
```
