### PR TITLE
feat: accept run function to return void

### DIFF
--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -54,9 +54,9 @@ JavaScript and TypeScript utilities for [Juno] Serverless Functions.
 
 #### :gear: RunFunctionSchema
 
-| Function            | Type                                                                                                        |
-| ------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `RunFunctionSchema` | `<T extends z.ZodTypeAny>(contextSchema: T) => ZodFunction<ZodTuple<[T], ZodUnknown>, ZodPromise<ZodVoid>>` |
+| Function            | Type                                                                                                                             |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `RunFunctionSchema` | `<T extends z.ZodTypeAny>(contextSchema: T) => ZodFunction<ZodTuple<[T], ZodUnknown>, ZodUnion<[ZodPromise<ZodVoid>, ZodVoid]>>` |
 
 [:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/context.ts#L47)
 
@@ -447,7 +447,7 @@ A schema that validates a value is an Uint8Array.
 
 | Constant         | Type                                                                                                                                                                                                                                                                                                                               |
 | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `OnSetDocSchema` | `ZodObject<extendShape<{ collections: ZodReadonly<ZodArray<ZodString, "many">>; }, { run: ZodFunction<ZodTuple<[ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<...>>; data: ZodObject<...>; }, "strict", ZodTypeAny, { ...; }, { ...; }>], ZodUnknown>, ZodPromise<...>>; }>, "strict", ZodTy...` |
+| `OnSetDocSchema` | `ZodObject<extendShape<{ collections: ZodReadonly<ZodArray<ZodString, "many">>; }, { run: ZodFunction<ZodTuple<[ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<...>>; data: ZodObject<...>; }, "strict", ZodTypeAny, { ...; }, { ...; }>], ZodUnknown>, ZodUnion<...>>; }>, "strict", ZodType...` |
 
 [:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/db/hooks.ts#L26)
 
@@ -455,7 +455,7 @@ A schema that validates a value is an Uint8Array.
 
 | Constant     | Type                                                                                                                                                                                                                                                                                                                               |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `HookSchema` | `ZodObject<extendShape<{ collections: ZodReadonly<ZodArray<ZodString, "many">>; }, { run: ZodFunction<ZodTuple<[ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<...>>; data: ZodObject<...>; }, "strict", ZodTypeAny, { ...; }, { ...; }>], ZodUnknown>, ZodPromise<...>>; }>, "strict", ZodTy...` |
+| `HookSchema` | `ZodObject<extendShape<{ collections: ZodReadonly<ZodArray<ZodString, "many">>; }, { run: ZodFunction<ZodTuple<[ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<...>>; data: ZodObject<...>; }, "strict", ZodTypeAny, { ...; }, { ...; }>], ZodUnknown>, ZodUnion<...>>; }>, "strict", ZodType...` |
 
 [:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/db/hooks.ts#L37)
 
@@ -685,7 +685,7 @@ The function takes a context argument and returns `void`.
 
 Defines the `run` function schema for hooks.
 
-The function takes a context argument and returns a `Promise<void>`.
+The function takes a context argument and returns either a `Promise<void>` or `void`.
 
 | Type          | Type                                                          |
 | ------------- | ------------------------------------------------------------- |

--- a/packages/functions/src/hooks/schemas/context.ts
+++ b/packages/functions/src/hooks/schemas/context.ts
@@ -45,12 +45,12 @@ export type AssertFunction<T> = z.infer<ReturnType<typeof AssertFunctionSchema<z
  * @see RunFunction
  */
 export const RunFunctionSchema = <T extends z.ZodTypeAny>(contextSchema: T) =>
-  z.function().args(contextSchema).returns(z.promise(z.void()));
+  z.function().args(contextSchema).returns(z.promise(z.void()).or(z.void()));
 
 /**
  * Defines the `run` function schema for hooks.
  *
- * The function takes a context argument and returns a `Promise<void>`.
+ * The function takes a context argument and returns either a `Promise<void>` or `void`.
  *
  * @template T - The type of context passed to the function.
  */

--- a/packages/functions/src/tests/hooks/schemas/context.spec.ts
+++ b/packages/functions/src/tests/hooks/schemas/context.spec.ts
@@ -62,13 +62,22 @@ describe('context', () => {
       field2: z.number()
     });
 
-    const validFunction = async (context: z.infer<typeof MockContextSchema>) => {
+    const validPromiseVoidFunction = async (context: z.infer<typeof MockContextSchema>) => {
       console.log('Function executed with:', context);
     };
 
-    it('should validate a correctly typed function', () => {
+    const validVoidFunction = (context: z.infer<typeof MockContextSchema>) => {
+      console.log('Function executed with:', context);
+    };
+
+    it('should validate a correctly typed function with return promise void', () => {
       const schema = RunFunctionSchema(MockContextSchema);
-      expect(() => schema.parse(validFunction)).not.toThrow();
+      expect(() => schema.parse(validPromiseVoidFunction)).not.toThrow();
+    });
+
+    it('should validate a correctly typed function with return void', () => {
+      const schema = RunFunctionSchema(MockContextSchema);
+      expect(() => schema.parse(validVoidFunction)).not.toThrow();
     });
 
     it('should reject a non-function value', () => {


### PR DESCRIPTION
For some scenario promise is not necessary for a run function, therefore it would be nice if it accepts void as well.