### PR TITLE
feat: accept empty collections

### DIFF
--- a/packages/functions/src/hooks/schemas/collections.ts
+++ b/packages/functions/src/hooks/schemas/collections.ts
@@ -6,9 +6,10 @@ import * as z from 'zod';
 export const CollectionsSchema = z
   .object({
     /**
-     * An array containing at least one collection name where the hook or assertion will be executed.
+     * An array of collection names where the hook or assertion will run.
+     * If empty, no hooks or assertions are triggered.
      */
-    collections: z.array(z.string()).min(1).readonly()
+    collections: z.array(z.string()).readonly()
   })
   .strict();
 

--- a/packages/functions/src/tests/hooks/db/assertions.spec.ts
+++ b/packages/functions/src/tests/hooks/db/assertions.spec.ts
@@ -43,9 +43,9 @@ describe('assert.config', () => {
       expect(() => AssertSetDocSchema.parse(mockAssertSetDocConfig)).not.toThrow();
     });
 
-    it('should reject an empty collections array', () => {
+    it('should accept an empty collections array', () => {
       const invalidConfig = {...mockAssertSetDocConfig, collections: []};
-      expect(() => AssertSetDocSchema.parse(invalidConfig)).toThrow();
+      expect(() => AssertSetDocSchema.parse(invalidConfig)).not.toThrow();
     });
 
     it('should reject an invalid assert function', () => {

--- a/packages/functions/src/tests/hooks/db/hooks.spec.ts
+++ b/packages/functions/src/tests/hooks/db/hooks.spec.ts
@@ -54,9 +54,9 @@ describe('hook.config', () => {
       expect(() => OnSetDocSchema.parse(mockOnSetDocConfig)).not.toThrow();
     });
 
-    it('should reject an empty collections array', () => {
+    it('should accept an empty collections array', () => {
       const invalidConfig = {...mockOnSetDocConfig, collections: []};
-      expect(() => OnSetDocSchema.parse(invalidConfig)).toThrow();
+      expect(() => OnSetDocSchema.parse(invalidConfig)).not.toThrow();
     });
 
     it('should reject an invalid run function', () => {

--- a/packages/functions/src/tests/hooks/schemas/collections.spec.ts
+++ b/packages/functions/src/tests/hooks/schemas/collections.spec.ts
@@ -11,9 +11,9 @@ describe('collections', () => {
     expect(() => CollectionsSchema.parse(validConfig)).not.toThrow();
   });
 
-  it('should reject an empty collections array', () => {
+  it('should accept an empty collections array', () => {
     const invalidConfig = {collections: []};
-    expect(() => CollectionsSchema.parse(invalidConfig)).toThrow();
+    expect(() => CollectionsSchema.parse(invalidConfig)).not.toThrow();
   });
 
   it('should reject missing collections field', () => {


### PR DESCRIPTION
This is useful for scaffolding templates. This way we don't enforce pseud collections when generating code for the dev.