### PR TITLE
fix: Zod - Type 'k' cannot be used to index type

### DIFF
--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -38,11 +38,11 @@ JavaScript and TypeScript utilities for [Juno] Serverless Functions.
 
 #### :gear: HookContextSchema
 
-| Function            | Type                                                                                                                                                                                                                                                                                                                          |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `HookContextSchema` | `<T extends z.ZodTypeAny>(dataSchema: T) => ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<ArrayBufferLike>>; data: T; }, "strict", ZodTypeAny, { [k in keyof addQuestionMarks<...>]: addQuestionMarks<...>[k]; }, { [k in keyof baseObjectInputType<...>]: baseObjectInputType<...>[k]; }>` |
+| Function            | Type                                                                                                                                                                                |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `HookContextSchema` | `<T extends z.ZodTypeAny>(dataSchema: T) => ZodObject<typeof schemaShape, "strict", ZodTypeAny, baseObjectOutputType<typeof schemaShape>, baseObjectInputType<typeof schemaShape>>` |
 
-[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/context.ts#L7)
+[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/context.ts#L8)
 
 #### :gear: AssertFunctionSchema
 
@@ -50,7 +50,7 @@ JavaScript and TypeScript utilities for [Juno] Serverless Functions.
 | ---------------------- | ----------------------------------------------------------------------------------------------- |
 | `AssertFunctionSchema` | `<T extends z.ZodTypeAny>(contextSchema: T) => ZodFunction<ZodTuple<[T], ZodUnknown>, ZodVoid>` |
 
-[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/context.ts#L32)
+[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/context.ts#L41)
 
 #### :gear: RunFunctionSchema
 
@@ -58,15 +58,15 @@ JavaScript and TypeScript utilities for [Juno] Serverless Functions.
 | ------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `RunFunctionSchema` | `<T extends z.ZodTypeAny>(contextSchema: T) => ZodFunction<ZodTuple<[T], ZodUnknown>, ZodUnion<[ZodPromise<ZodVoid>, ZodVoid]>>` |
 
-[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/context.ts#L47)
+[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/context.ts#L56)
 
 #### :gear: DocContextSchema
 
-| Function           | Type                                                                                                                                                                                                                                                                                                                               |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DocContextSchema` | `<T extends z.ZodTypeAny>(dataSchema: T) => ZodObject<{ collection: ZodString; key: ZodString; data: T; }, "strict", ZodTypeAny, { [k in keyof addQuestionMarks<baseObjectOutputType<{ collection: ZodString; key: ZodString; data: T; }>, any>]: addQuestionMarks<...>[k]; }, { [k in keyof baseObjectInputType<...>]: baseOb...` |
+| Function           | Type                                                                                                                                                                                |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DocContextSchema` | `<T extends z.ZodTypeAny>(dataSchema: T) => ZodObject<typeof schemaShape, "strict", ZodTypeAny, baseObjectOutputType<typeof schemaShape>, baseObjectInputType<typeof schemaShape>>` |
 
-[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/db/context.ts#L9)
+[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/db/context.ts#L10)
 
 #### :gear: AssertFnSchema
 
@@ -405,19 +405,19 @@ A schema that validates a value is an Uint8Array.
 
 #### :gear: OnSetDocContextSchema
 
-| Constant                | Type                                                                                                                                                                    |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `OnSetDocContextSchema` | `ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<ArrayBufferLike>>; data: ZodObject<...>; }, "strict", ZodTypeAny, { ...; }, { ...; }>` |
+| Constant                | Type                                                                                                                                                                                                     |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OnSetDocContextSchema` | `ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<ArrayBufferLike>>; data: ZodObject<...>; }, "strict", ZodTypeAny, baseObjectOutputType<...>, baseObjectInputType<...>>` |
 
-[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/db/context.ts#L39)
+[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/db/context.ts#L48)
 
 #### :gear: AssertSetDocContextSchema
 
-| Constant                    | Type                                                                                                                                                                    |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `AssertSetDocContextSchema` | `ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<ArrayBufferLike>>; data: ZodObject<...>; }, "strict", ZodTypeAny, { ...; }, { ...; }>` |
+| Constant                    | Type                                                                                                                                                                                                     |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AssertSetDocContextSchema` | `ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<ArrayBufferLike>>; data: ZodObject<...>; }, "strict", ZodTypeAny, baseObjectOutputType<...>, baseObjectInputType<...>>` |
 
-[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/db/context.ts#L52)
+[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/db/context.ts#L61)
 
 #### :gear: SatelliteEnvSchema
 
@@ -431,7 +431,7 @@ A schema that validates a value is an Uint8Array.
 
 | Constant             | Type                                                                                                                                                                                                                                                                                                                               |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `AssertSetDocSchema` | `ZodObject<extendShape<{ collections: ZodReadonly<ZodArray<ZodString, "many">>; }, { assert: ZodFunction<ZodTuple<[ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<...>>; data: ZodObject<...>; }, "strict", ZodTypeAny, { ...; }, { ...; }>], ZodUnknown>, ZodVoid>; }>, "strict", ZodTypeAny...` |
+| `AssertSetDocSchema` | `ZodObject<extendShape<{ collections: ZodReadonly<ZodArray<ZodString, "many">>; }, { assert: ZodFunction<ZodTuple<[ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<...>>; data: ZodObject<...>; }, "strict", ZodTypeAny, baseObjectOutputType<...>, baseObjectInputType<...>>], ZodUnknown>, Z...` |
 
 [:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/db/assertions.ts#L26)
 
@@ -439,7 +439,7 @@ A schema that validates a value is an Uint8Array.
 
 | Constant       | Type                                                                                                                                                                                                                                                                                                                               |
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `AssertSchema` | `ZodObject<extendShape<{ collections: ZodReadonly<ZodArray<ZodString, "many">>; }, { assert: ZodFunction<ZodTuple<[ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<...>>; data: ZodObject<...>; }, "strict", ZodTypeAny, { ...; }, { ...; }>], ZodUnknown>, ZodVoid>; }>, "strict", ZodTypeAny...` |
+| `AssertSchema` | `ZodObject<extendShape<{ collections: ZodReadonly<ZodArray<ZodString, "many">>; }, { assert: ZodFunction<ZodTuple<[ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<...>>; data: ZodObject<...>; }, "strict", ZodTypeAny, baseObjectOutputType<...>, baseObjectInputType<...>>], ZodUnknown>, Z...` |
 
 [:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/db/assertions.ts#L37)
 
@@ -447,7 +447,7 @@ A schema that validates a value is an Uint8Array.
 
 | Constant         | Type                                                                                                                                                                                                                                                                                                                               |
 | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `OnSetDocSchema` | `ZodObject<extendShape<{ collections: ZodReadonly<ZodArray<ZodString, "many">>; }, { run: ZodFunction<ZodTuple<[ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<...>>; data: ZodObject<...>; }, "strict", ZodTypeAny, { ...; }, { ...; }>], ZodUnknown>, ZodUnion<...>>; }>, "strict", ZodType...` |
+| `OnSetDocSchema` | `ZodObject<extendShape<{ collections: ZodReadonly<ZodArray<ZodString, "many">>; }, { run: ZodFunction<ZodTuple<[ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<...>>; data: ZodObject<...>; }, "strict", ZodTypeAny, baseObjectOutputType<...>, baseObjectInputType<...>>], ZodUnknown>, ZodU...` |
 
 [:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/db/hooks.ts#L26)
 
@@ -455,7 +455,7 @@ A schema that validates a value is an Uint8Array.
 
 | Constant     | Type                                                                                                                                                                                                                                                                                                                               |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `HookSchema` | `ZodObject<extendShape<{ collections: ZodReadonly<ZodArray<ZodString, "many">>; }, { run: ZodFunction<ZodTuple<[ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<...>>; data: ZodObject<...>; }, "strict", ZodTypeAny, { ...; }, { ...; }>], ZodUnknown>, ZodUnion<...>>; }>, "strict", ZodType...` |
+| `HookSchema` | `ZodObject<extendShape<{ collections: ZodReadonly<ZodArray<ZodString, "many">>; }, { run: ZodFunction<ZodTuple<[ZodObject<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<...>>; data: ZodObject<...>; }, "strict", ZodTypeAny, baseObjectOutputType<...>, baseObjectInputType<...>>], ZodUnknown>, ZodU...` |
 
 [:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/db/hooks.ts#L37)
 
@@ -667,7 +667,7 @@ Represents the context provided to hooks, containing information about the calle
 | ------------- | -------------------------------------------------- |
 | `HookContext` | `z.infer<ReturnType<typeof HookContextSchema<T>>>` |
 
-[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/context.ts#L27)
+[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/context.ts#L36)
 
 #### :gear: AssertFunction
 
@@ -679,7 +679,7 @@ The function takes a context argument and returns `void`.
 | ---------------- | ---------------------------------------------------------------- |
 | `AssertFunction` | `z.infer<ReturnType<typeof AssertFunctionSchema<z.ZodType<T>>>>` |
 
-[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/context.ts#L42)
+[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/context.ts#L51)
 
 #### :gear: RunFunction
 
@@ -691,7 +691,7 @@ The function takes a context argument and returns either a `Promise<void>` or `v
 | ------------- | ------------------------------------------------------------- |
 | `RunFunction` | `z.infer<ReturnType<typeof RunFunctionSchema<z.ZodType<T>>>>` |
 
-[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/context.ts#L57)
+[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/context.ts#L66)
 
 #### :gear: DocDescription
 
@@ -769,7 +769,7 @@ Represents the context of a document operation within a collection.
 | ------------ | ------------------------------------------------- |
 | `DocContext` | `z.infer<ReturnType<typeof DocContextSchema<T>>>` |
 
-[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/db/context.ts#L34)
+[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/db/context.ts#L43)
 
 #### :gear: OnSetDocContext
 
@@ -782,7 +782,7 @@ along with details about the user who triggered the operation.
 | ----------------- | --------------------------------------- |
 | `OnSetDocContext` | `z.infer<typeof OnSetDocContextSchema>` |
 
-[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/db/context.ts#L47)
+[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/db/context.ts#L56)
 
 #### :gear: AssertSetDocContext
 
@@ -795,7 +795,7 @@ it is created or updated. If validation fails, the developer should throw an err
 | --------------------- | ------------------------------------------- |
 | `AssertSetDocContext` | `z.infer<typeof AssertSetDocContextSchema>` |
 
-[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/db/context.ts#L60)
+[:link: Source](https://github.com/junobuild/juno-js/tree/main/packages/functions/src/hooks/schemas/db/context.ts#L69)
 
 #### :gear: SatelliteEnv
 

--- a/packages/functions/src/hooks/schemas/context.ts
+++ b/packages/functions/src/hooks/schemas/context.ts
@@ -1,23 +1,32 @@
+import type {baseObjectInputType, baseObjectOutputType, ZodObject, ZodTypeAny} from 'zod';
 import * as z from 'zod';
 import {RawUserIdSchema} from '../../schemas/satellite';
 
 /**
  * @see HookContext
  */
-export const HookContextSchema = <T extends z.ZodTypeAny>(dataSchema: T) =>
-  z
-    .object({
-      /**
-       * The user who originally triggered the function that in turn triggered the hook.
-       */
-      caller: RawUserIdSchema,
+export const HookContextSchema = <T extends z.ZodTypeAny>(dataSchema: T) => {
+  const schemaShape = {
+    /**
+     * The user who originally triggered the function that in turn triggered the hook.
+     */
+    caller: RawUserIdSchema,
 
-      /**
-       * The data associated with the hook execution.
-       */
-      data: dataSchema
-    })
-    .strict();
+    /**
+     * The data associated with the hook execution.
+     */
+    data: dataSchema
+  };
+
+  // TODO: workaround for https://github.com/colinhacks/zod/issues/3998
+  return z.object(schemaShape).strict() as ZodObject<
+    typeof schemaShape,
+    'strict',
+    ZodTypeAny,
+    baseObjectOutputType<typeof schemaShape>,
+    baseObjectInputType<typeof schemaShape>
+  >;
+};
 
 /**
  * Represents the context provided to hooks, containing information about the caller and related data.

--- a/packages/functions/src/hooks/schemas/db/context.ts
+++ b/packages/functions/src/hooks/schemas/db/context.ts
@@ -1,3 +1,4 @@
+import type {baseObjectInputType, baseObjectOutputType, ZodObject, ZodTypeAny} from 'zod';
 import * as z from 'zod';
 import {CollectionSchema, KeySchema} from '../../../schemas/satellite';
 import {HookContextSchema} from '../context';
@@ -6,25 +7,33 @@ import {DocAssertSetSchema, DocUpsertSchema} from './payload';
 /**
  * @see DocContext
  */
-export const DocContextSchema = <T extends z.ZodTypeAny>(dataSchema: T) =>
-  z
-    .object({
-      /**
-       * The name of the collection where the document is stored.
-       */
-      collection: CollectionSchema,
+export const DocContextSchema = <T extends z.ZodTypeAny>(dataSchema: T) => {
+  const schemaShape = {
+    /**
+     * The name of the collection where the document is stored.
+     */
+    collection: CollectionSchema,
 
-      /**
-       * The unique key identifying the document within the collection.
-       */
-      key: KeySchema,
+    /**
+     * The unique key identifying the document within the collection.
+     */
+    key: KeySchema,
 
-      /**
-       * The data associated with the document operation.
-       */
-      data: dataSchema
-    })
-    .strict();
+    /**
+     * The data associated with the document operation.
+     */
+    data: dataSchema
+  };
+
+  // TODO: workaround for https://github.com/colinhacks/zod/issues/3998
+  return z.object(schemaShape).strict() as ZodObject<
+    typeof schemaShape,
+    'strict',
+    ZodTypeAny,
+    baseObjectOutputType<typeof schemaShape>,
+    baseObjectInputType<typeof schemaShape>
+  >;
+};
 
 /**
  * Represents the context of a document operation within a collection.


### PR DESCRIPTION
# Motivation

Resolve following error when library is build with `tsc`:

```
❯ npm run build

> @junobuild/cli@0.2.0 build
> tsc --noEmit && node ./scripts/rmdir.mjs && node ./scripts/esbuild.mjs

node_modules/@junobuild/functions/hooks/schemas/context.d.ts:23:50 - error TS2536: Type 'k' cannot be used to index type 'addQuestionMarks<baseObjectOutputType<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<ArrayBufferLike>>; data: T; }>, any>'.

 23 }>, any> extends infer T_1 ? { [k in keyof T_1]: z.objectUtil.addQuestionMarks<z.baseObjectOutputType<{
                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 24     /**
    ~~~~~~~
... 
 31     data: T;
    ~~~~~~~~~~~~
 32 }>, any>[k]; } : never, z.baseObjectInputType<{
    ~~~~~~~~~~~

node_modules/@junobuild/functions/hooks/schemas/context.d.ts:41:46 - error TS2536: Type 'k_1' cannot be used to index type 'baseObjectInputType<{ caller: ZodType<Uint8Array<ArrayBufferLike>, ZodTypeDef, Uint8Array<ArrayBufferLike>>; data: T; }>'.

 41 }> extends infer T_2 ? { [k_1 in keyof T_2]: z.baseObjectInputType<{
                                                 ~~~~~~~~~~~~~~~~~~~~~~~
 42     /**
    ~~~~~~~
... 
 49     data: T;
    ~~~~~~~~~~~~
 50 }>[k_1]; } : never>;
    ~~~~~~~

node_modules/@junobuild/functions/hooks/schemas/db/context.d.ts:31:50 - error TS2536: Type 'k' cannot be used to index type 'addQuestionMarks<baseObjectOutputType<{ collection: ZodString; key: ZodString; data: T; }>, any>'.

 31 }>, any> extends infer T_1 ? { [k in keyof T_1]: z.objectUtil.addQuestionMarks<z.baseObjectOutputType<{
                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 32     /**
    ~~~~~~~
... 
 43     data: T;
    ~~~~~~~~~~~~
 44 }>, any>[k]; } : never, z.baseObjectInputType<{
    ~~~~~~~~~~~

node_modules/@junobuild/functions/hooks/schemas/db/context.d.ts:57:46 - error TS2536: Type 'k_1' cannot be used to index type 'baseObjectInputType<{ collection: ZodString; key: ZodString; data: T; }>'.

 57 }> extends infer T_2 ? { [k_1 in keyof T_2]: z.baseObjectInputType<{
                                                 ~~~~~~~~~~~~~~~~~~~~~~~
 58     /**
    ~~~~~~~
... 
 69     data: T;
    ~~~~~~~~~~~~
 70 }>[k_1]; } : never>;
    ~~~~~~~


Found 4 errors in 2 files.

Errors  Files
     2  node_modules/@junobuild/functions/hooks/schemas/context.d.ts:23
     2  node_modules/@junobuild/functions/hooks/schemas/db/context.d.ts:31
```

# Workaround

This was reported in Zod and workaround was provided in the issue: https://github.com/colinhacks/zod/issues/3998