### PR TITLE
feat: disable agent-js console.warn

### DIFF
--- a/packages/admin/src/api/ic.api.ts
+++ b/packages/admin/src/api/ic.api.ts
@@ -155,6 +155,11 @@ export const canisterMetadata = async ({
 
   const agent = await useOrInitAgent(rest);
 
+  // TODO: Workaround for agent-js. Disable console.warn.
+  // See https://github.com/dfinity/agent-js/issues/843
+  const hideAgentJsConsoleWarn = globalThis.console.warn;
+  globalThis.console.warn = (): null => null;
+
   const result = await CanisterStatus.request({
     canisterId: canisterId instanceof Principal ? canisterId : Principal.fromText(canisterId),
     agent,
@@ -167,6 +172,9 @@ export const canisterMetadata = async ({
       }
     ]
   });
+
+  // Redo console.warn
+  globalThis.console.warn = hideAgentJsConsoleWarn;
 
   return result.get(path);
 };


### PR DESCRIPTION
I've got this piece of code in the CLI and the warn are also annoying in the Console UI.
Therefore let's make the workaround to silence agent-js available in all consumers.

Relates to https://github.com/dfinity/agent-js/issues/843