### PR TITLE
feat: find juno package dependency

### DIFF
--- a/packages/admin/src/services/package.services.ts
+++ b/packages/admin/src/services/package.services.ts
@@ -77,3 +77,40 @@ export const getJunoPackageVersion = async (
   const pkg = await getJunoPackage(params);
   return pkg?.version;
 };
+
+/**
+ * Retrieves the `dependencies` field from the `juno:package` metadata.
+ *
+ * @param {GetJunoPackageParams} params - The parameters to fetch the package metadata.
+ *
+ * @returns {Promise<JunoPackage['dependencies'] | undefined>} A promise that resolves to the dependencies object or `undefined` if not found.
+ *
+ * @throws {ZodError} If the metadata exists but does not conform to the expected `JunoPackage` schema.
+ */
+export const getJunoPackageDependencies = async (
+  params: GetJunoPackageParams
+): Promise<JunoPackage['dependencies'] | undefined> => {
+  const pkg = await getJunoPackage(params);
+  return pkg?.dependencies;
+};
+
+/**
+ * Finds a specific dependency entry by its ID from the `juno:package` metadata.
+ *
+ * @param {Object} params - The parameters to fetch and search within the dependencies.
+ * @param {string} params.dependencyId - The ID of the dependency to find (e.g., `@junobuild/satellite`).
+ * @param {Principal | string} params.moduleId - The canister ID (as a `Principal` or string).
+ * @param {ActorParameters} params - Additional actor parameters required for the metadata call.
+ *
+ * @returns {Promise<[string, string] | undefined>} A promise that resolves to the `[dependencyId, version]` tuple if found, or `undefined` otherwise.
+ *
+ * @throws {ZodError} If the metadata exists but does not conform to the expected `JunoPackage` schema.
+ */
+export const findJunoPackageDependency = async ({
+  dependencyId,
+  ...params
+}: GetJunoPackageParams & {dependencyId: string}): Promise<[string, string] | undefined> => {
+  const dependencies = await getJunoPackageDependencies(params);
+
+  return Object.entries(dependencies ?? {}).find(([key, _]) => key === dependencyId);
+};

--- a/packages/config/src/constants/juno.package.constants.ts
+++ b/packages/config/src/constants/juno.package.constants.ts
@@ -1,0 +1,13 @@
+/**
+ * The dependency ID used to identify a Juno Satellite crate.
+ *
+ * Used when checking if a canister includes `@junobuild/satellite` as a dependency.
+ */
+export const JUNO_PACKAGE_SATELLITE_ID = '@junobuild/satellite';
+
+/**
+ * The dependency ID used to identify a Juno Sputnik crate.
+ *
+ * Used when checking if a canister includes `@junobuild/sputnik` as a dependency.
+ */
+export const JUNO_PACKAGE_SPUTNIK_ID = '@junobuild/sputnik';

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -16,6 +16,7 @@ export type * from './types/juno.env';
 export type * from './types/juno.package';
 export type * from './types/utility.types';
 
+export * from './constants/juno.package.constants';
 export * from './schema/juno.package.schema';
 
 /// Export and expose functions for developers' configuration


### PR DESCRIPTION
It will be handy, both in the CLI and Console UI, to have a way to search for the satellite dependency in the Juno Package metadata.