### PR TITLE
feat: deprecated satellite build_version()

### DIFF
--- a/packages/admin/src/api/satellite.api.ts
+++ b/packages/admin/src/api/satellite.api.ts
@@ -118,18 +118,6 @@ export const version = async ({satellite}: {satellite: SatelliteParameters}): Pr
 };
 
 /**
- * @deprecated - Replaced in Satellite > v0.0.22 with public custom section juno:package
- */
-export const buildVersion = async ({
-  satellite
-}: {
-  satellite: SatelliteParameters;
-}): Promise<string> => {
-  const {build_version} = await getDeprecatedSatelliteVersionActor(satellite);
-  return build_version();
-};
-
-/**
  * @deprecated TODO: for backwards compatibility - to be removed
  */
 export const listDeprecatedControllers = async ({

--- a/packages/admin/src/services/satellite.version.services.ts
+++ b/packages/admin/src/services/satellite.version.services.ts
@@ -1,6 +1,6 @@
 import {nonNullish} from '@dfinity/utils';
 import {canisterMetadata} from '../api/ic.api';
-import {buildVersion, version} from '../api/satellite.api';
+import {version} from '../api/satellite.api';
 import type {SatelliteParameters} from '../types/actor.types';
 import type {BuildType} from '../types/build.types';
 
@@ -12,15 +12,6 @@ import type {BuildType} from '../types/build.types';
  */
 export const satelliteVersion = (params: {satellite: SatelliteParameters}): Promise<string> =>
   version(params);
-
-/**
- * Retrieves the build version of the satellite.
- * @param {Object} params - The parameters for retrieving the build version.
- * @param {SatelliteParameters} params.satellite - The satellite parameters.
- * @returns {Promise<string>} A promise that resolves to the build version of the satellite.
- */
-export const satelliteBuildVersion = (params: {satellite: SatelliteParameters}): Promise<string> =>
-  buildVersion(params);
 
 /**
  * Retrieves the build type of the satellite.


### PR DESCRIPTION
Once I update the Console UI for backwards compatibility, it seems we do not use this elsewhere. So let's do a breaking change.