### PR TITLE
refactor: move tests - webstorm issue

### DIFF
--- a/packages/analytics/src/tests/api/orbiter.api.spec.ts
+++ b/packages/analytics/src/tests/api/orbiter.api.spec.ts
@@ -1,4 +1,7 @@
 import type {Mock} from 'vitest';
+import {ApiError, OrbiterApi} from '../../api/orbiter.api';
+import {Environment} from '../../types/env';
+import {jsonReplacer} from '../../utils/dfinity/json.utils';
 import {
   okResponseMock,
   orbiterIdMock,
@@ -6,9 +9,6 @@ import {
   performanceMetricsRequestMock,
   trackEventsRequestMock
 } from '../mocks/orbiter.mock';
-import {Environment} from '../types/env';
-import {jsonReplacer} from '../utils/dfinity/json.utils';
-import {ApiError, OrbiterApi} from './orbiter.api';
 
 vi.mock('../src/constants/container.constants', () => ({
   DOCKER_CONTAINER_WEB_URL: 'http://localhost:5973'

--- a/packages/analytics/src/tests/index.spec.ts
+++ b/packages/analytics/src/tests/index.spec.ts
@@ -6,7 +6,7 @@ import {initOrbiter} from '../index';
 import {PerformanceServices} from '../services/performance.services';
 import {UserAgentServices} from '../services/user-agent.services';
 
-vi.mock('./utils/window.env.utils', () => ({
+vi.mock('../utils/window.env.utils', () => ({
   envSatelliteId: vi.fn(() => 'satellite-from-env'),
   envOrbiterId: vi.fn(() => 'orbiter-from-env'),
   envContainer: vi.fn(() => undefined)

--- a/packages/analytics/src/tests/index.spec.ts
+++ b/packages/analytics/src/tests/index.spec.ts
@@ -2,9 +2,9 @@
  * @vitest-environment jsdom
  */
 
-import {initOrbiter} from './index';
-import {PerformanceServices} from './services/performance.services';
-import {UserAgentServices} from './services/user-agent.services';
+import {initOrbiter} from '../index';
+import {PerformanceServices} from '../services/performance.services';
+import {UserAgentServices} from '../services/user-agent.services';
 
 vi.mock('./utils/window.env.utils', () => ({
   envSatelliteId: vi.fn(() => 'satellite-from-env'),

--- a/packages/analytics/src/tests/mocks/orbiter.mock.ts
+++ b/packages/analytics/src/tests/mocks/orbiter.mock.ts
@@ -6,7 +6,7 @@ import type {
   SetPerformanceMetricsRequest,
   SetTrackEventPayload,
   SetTrackEventsRequest
-} from '../types/orbiter';
+} from '../../types/orbiter';
 
 const {timeZone} = Intl.DateTimeFormat().resolvedOptions();
 

--- a/packages/analytics/src/tests/services/orbiter.services.spec.ts
+++ b/packages/analytics/src/tests/services/orbiter.services.spec.ts
@@ -1,5 +1,8 @@
 import type {Mock} from 'vitest';
-import {ApiError} from '../api/orbiter.api';
+import {ApiError} from '../../api/orbiter.api';
+import {OrbiterServices} from '../../services/orbiter.services';
+import {Environment} from '../../types/env';
+import {jsonReplacer} from '../../utils/dfinity/json.utils';
 import {
   okResponseMock,
   orbiterIdMock,
@@ -8,9 +11,6 @@ import {
   satelliteIdMock,
   trackEventsRequestMock
 } from '../mocks/orbiter.mock';
-import {Environment} from '../types/env';
-import {jsonReplacer} from '../utils/dfinity/json.utils';
-import {OrbiterServices} from './orbiter.services';
 
 vi.mock('../src/constants/container.constants', () => ({
   DOCKER_CONTAINER_WEB_URL: 'http://localhost:5973'

--- a/packages/analytics/src/tests/services/performance.services.spec.ts
+++ b/packages/analytics/src/tests/services/performance.services.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import type {Mock} from 'vitest';
-import {PerformanceServices} from './performance.services';
+import {PerformanceServices} from '../../services/performance.services';
 
 vi.mock('web-vitals', () => ({
   onCLS: vi.fn(),

--- a/packages/analytics/src/tests/services/user-agent.services.spec.ts
+++ b/packages/analytics/src/tests/services/user-agent.services.spec.ts
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 
-import {UserAgentServices} from './user-agent.services';
+import {UserAgentServices} from '../../services/user-agent.services';
 
 describe('user-agent.services', () => {
   const {parseUserAgent} = new UserAgentServices();

--- a/packages/analytics/src/tests/tracker.spec.ts
+++ b/packages/analytics/src/tests/tracker.spec.ts
@@ -3,10 +3,10 @@
  */
 
 import type {Mock, MockInstance} from 'vitest';
+import {PerformanceServices} from '../services/performance.services';
+import * as trackerHelpers from '../tracker';
+import {jsonReviver} from '../utils/dfinity/json.utils';
 import {orbiterIdMock, satelliteIdMock} from './mocks/orbiter.mock';
-import {PerformanceServices} from './services/performance.services';
-import * as trackerHelpers from './tracker';
-import {jsonReviver} from './utils/dfinity/json.utils';
 
 vi.mock('web-vitals', () => ({
   onCLS: vi.fn(),

--- a/packages/analytics/src/tests/tsconfig.json
+++ b/packages/analytics/src/tests/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../tsconfig.spec.json"
+}

--- a/packages/analytics/src/tests/utils/analytics.utils.spec.ts
+++ b/packages/analytics/src/tests/utils/analytics.utils.spec.ts
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 
-import {timestamp, userAgent} from './analytics.utils';
+import {timestamp, userAgent} from '../../utils/analytics.utils';
 
 describe('analytics.utils', () => {
   describe('timestamp', () => {

--- a/packages/analytics/src/tests/utils/date.utils.spec.ts
+++ b/packages/analytics/src/tests/utils/date.utils.spec.ts
@@ -1,4 +1,4 @@
-import {nowInBigIntNanoSeconds} from './date.utils';
+import {nowInBigIntNanoSeconds} from '../../utils/date.utils';
 
 describe('date.utils', () => {
   describe('nowInBigIntNanoSeconds', () => {

--- a/packages/analytics/src/tests/utils/dfinity/asserts.utils.spec.ts
+++ b/packages/analytics/src/tests/utils/dfinity/asserts.utils.spec.ts
@@ -4,7 +4,7 @@ import {
   assertPercentageNumber,
   InvalidPercentageError,
   NullishError
-} from './asserts.utils';
+} from '../../../utils/dfinity/asserts.utils';
 
 describe('asserts-utils', () => {
   describe('assertNonNullish', () => {

--- a/packages/analytics/src/tests/utils/dfinity/debounce.utils.spec.ts
+++ b/packages/analytics/src/tests/utils/dfinity/debounce.utils.spec.ts
@@ -1,4 +1,4 @@
-import {debounce} from './debounce.utils';
+import {debounce} from '../../../utils/dfinity/debounce.utils';
 
 describe('debounce-utils', () => {
   let callback: ReturnType<typeof vi.fn>;

--- a/packages/analytics/src/tests/utils/dfinity/json.utils.spec.ts
+++ b/packages/analytics/src/tests/utils/dfinity/json.utils.spec.ts
@@ -1,4 +1,4 @@
-import {jsonReplacer, jsonReviver} from './json.utils';
+import {jsonReplacer, jsonReviver} from '../../../utils/dfinity/json.utils';
 
 describe('json-utils', () => {
   describe('stringify', () => {

--- a/packages/analytics/src/tests/utils/dfinity/nullish.utils.spec.ts
+++ b/packages/analytics/src/tests/utils/dfinity/nullish.utils.spec.ts
@@ -1,4 +1,9 @@
-import {isEmptyString, isNullish, nonNullish, notEmptyString} from './nullish.utils';
+import {
+  isEmptyString,
+  isNullish,
+  nonNullish,
+  notEmptyString
+} from '../../../utils/dfinity/nullish.utils';
 
 describe('nullish-utils', () => {
   describe('isNullish', () => {

--- a/packages/analytics/src/tests/utils/env.utils.spec.ts
+++ b/packages/analytics/src/tests/utils/env.utils.spec.ts
@@ -1,4 +1,4 @@
-import {isBrowser} from './env.utils';
+import {isBrowser} from '../../utils/env.utils';
 
 describe('env.utils', () => {
   afterAll(() => {

--- a/packages/analytics/src/tests/utils/log.utils.spec.ts
+++ b/packages/analytics/src/tests/utils/log.utils.spec.ts
@@ -1,4 +1,4 @@
-import {warningOrbiterServicesNotInitialized} from './log.utils';
+import {warningOrbiterServicesNotInitialized} from '../../utils/log.utils';
 
 describe('log.utils', () => {
   const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/analytics/src/tests/utils/window.env.utils.spec.ts
+++ b/packages/analytics/src/tests/utils/window.env.utils.spec.ts
@@ -1,4 +1,4 @@
-import {envContainer, envOrbiterId, envSatelliteId} from './window.env.utils';
+import {envContainer, envOrbiterId, envSatelliteId} from '../../utils/window.env.utils';
 
 describe('window.env.utils', () => {
   const originalEnv = process.env;


### PR DESCRIPTION
Out of nowhere Webstorm starts to not recognizing the vi global and show errors in every tests. Then a day later, it stops doing so. Then a day later it starts again etc.

Annoying. So let's move the tests in a separate folder since Webstorm recognize only a single tsconfig file.