### PR TITLE
fix: uaparser dynamic import through default

### DIFF
--- a/packages/analytics/src/services/user-agent.services.ts
+++ b/packages/analytics/src/services/user-agent.services.ts
@@ -8,9 +8,9 @@ export class UserAgentServices {
       return undefined;
     }
 
-    const {UAParser} = await import('ua-parser-js');
+    const UAParser = await import('ua-parser-js');
 
-    const parser = new UAParser(user_agent);
+    const parser = new UAParser.default(user_agent);
     const {browser, os, device} = parser.getResult();
 
     if (isNullish(browser.name) || isNullish(os.name)) {


### PR DESCRIPTION
```
Uncaught (in promise) TypeError: t is not a constructor
    at ih.parseUserAgent (index.astro_astro_type_script_index_0_lang.BmfQMX7Q.js:48:30901)
    at async Au (index.astro_astro_type_script_index_0_lang.BmfQMX7Q.js:48:31943)
```