### PR TITLE
feat: clean href when collecting campaign

### DIFF
--- a/packages/analytics/src/tests/tracker.spec.ts
+++ b/packages/analytics/src/tests/tracker.spec.ts
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 
-import {describe, Mock, MockInstance} from 'vitest';
+import type {Mock, MockInstance} from 'vitest';
 import {PerformanceServices} from '../services/performance.services';
 import * as trackerHelpers from '../tracker';
 import {jsonReviver} from '../utils/dfinity/json.utils';

--- a/packages/analytics/src/tests/utils/analytics.utils.spec.ts
+++ b/packages/analytics/src/tests/utils/analytics.utils.spec.ts
@@ -68,25 +68,27 @@ describe('analytics.utils', () => {
       window.history.replaceState({}, '', originalWindowLocation);
     });
 
-    it('should return empty object if utm_source is missing', () => {
+    it('should return withCampaign: false if utm_source is missing', () => {
       mockSearchParams('?utm_medium=social&utm_campaign=test-campaign');
-      expect(campaign()).toEqual({});
+      expect(campaign()).toEqual({withCampaign: false});
     });
 
-    it('should return campaign with only utm_source', () => {
+    it('should return withCampaign: true and only utm_source', () => {
       mockSearchParams('?utm_source=twitter');
       expect(campaign()).toEqual({
+        withCampaign: true,
         campaign: {
           utm_source: 'twitter'
         }
       });
     });
 
-    it('should return campaign with all UTM parameters', () => {
+    it('should return withCampaign: true and all UTM parameters', () => {
       mockSearchParams(
         '?utm_source=twitter&utm_medium=social&utm_campaign=test-campaign&utm_term=abc&utm_content=xyz'
       );
       expect(campaign()).toEqual({
+        withCampaign: true,
         campaign: {
           utm_source: 'twitter',
           utm_medium: 'social',
@@ -100,6 +102,7 @@ describe('analytics.utils', () => {
     it('should exclude empty strings in optional fields', () => {
       mockSearchParams('?utm_source=twitter&utm_medium=&utm_term=123');
       expect(campaign()).toEqual({
+        withCampaign: true,
         campaign: {
           utm_source: 'twitter',
           utm_term: '123'
@@ -107,14 +110,14 @@ describe('analytics.utils', () => {
       });
     });
 
-    it('should return empty object if search is empty string', () => {
+    it('should return withCampaign: false if search is empty string', () => {
       mockSearchParams('');
-      expect(campaign()).toEqual({});
+      expect(campaign()).toEqual({withCampaign: false});
     });
 
-    it('should return empty object if search is undefined', () => {
+    it('should return withCampaign: false if search is undefined', () => {
       mockSearchParams(undefined);
-      expect(campaign()).toEqual({});
+      expect(campaign()).toEqual({withCampaign: false});
     });
   });
 });

--- a/packages/analytics/src/tracker.ts
+++ b/packages/analytics/src/tracker.ts
@@ -112,9 +112,7 @@ export const setPageView = async () => {
       return href;
     }
 
-    Object.keys(campaignData ?? {}).forEach((key) =>
-      url.searchParams.delete(key)
-    );
+    Object.keys(campaignData ?? {}).forEach((key) => url.searchParams.delete(key));
 
     return url.href;
   };

--- a/packages/analytics/src/utils/analytics.utils.ts
+++ b/packages/analytics/src/utils/analytics.utils.ts
@@ -11,7 +11,7 @@ export const userAgent = (): Pick<SetPageViewPayload, 'user_agent'> => {
   return nonNullish(userAgent) ? {user_agent: userAgent} : {};
 };
 
-export const campaign = (): Pick<SetPageViewPayload, 'campaign'> => {
+export const campaign = (): {withCampaign: boolean} & Pick<SetPageViewPayload, 'campaign'> => {
   const {
     location: {search}
   } = document;
@@ -21,7 +21,7 @@ export const campaign = (): Pick<SetPageViewPayload, 'campaign'> => {
   const utm_source = searchParams.get('utm_source');
 
   if (isNullish(utm_source) || isEmptyString(utm_source)) {
-    return {};
+    return {withCampaign: false};
   }
 
   const utm_medium = searchParams.get('utm_medium');
@@ -30,6 +30,7 @@ export const campaign = (): Pick<SetPageViewPayload, 'campaign'> => {
   const utm_content = searchParams.get('utm_content');
 
   return {
+    withCampaign: true,
     campaign: {
       utm_source,
       ...(notEmptyString(utm_medium) && {utm_medium}),


### PR DESCRIPTION
If we collect campaign data separatly we don't want those in the href.