### PR TITLE
fix: revert custom memory_size usage

### DIFF
--- a/packages/admin/declarations/orbiter/orbiter.did.d.ts
+++ b/packages/admin/declarations/orbiter/orbiter.did.d.ts
@@ -44,6 +44,8 @@ export interface AnalyticsOperatingSystemsPageViews {
 export interface AnalyticsTop10PageViews {
   referrers: Array<[string, number]>;
   pages: Array<[string, number]>;
+  utm_campaigns: [] | [Array<[string, number]>];
+  utm_sources: [] | [Array<[string, number]>];
   time_zones: [] | [Array<[string, number]>];
 }
 export interface AnalyticsTrackEvents {
@@ -101,6 +103,10 @@ export interface HttpResponse {
   upgrade: [] | [boolean];
   status_code: number;
 }
+export interface MemorySize {
+  stable: bigint;
+  heap: bigint;
+}
 export type NavigationType =
   | {Navigate: null}
   | {Restore: null}
@@ -127,12 +133,20 @@ export interface PageView {
   referrer: [] | [string];
   time_zone: string;
   session_id: string;
+  campaign: [] | [PageViewCampaign];
   href: string;
   created_at: bigint;
   satellite_id: Principal;
   device: PageViewDevice;
   version: [] | [bigint];
   user_agent: [] | [string];
+}
+export interface PageViewCampaign {
+  utm_content: [] | [string];
+  utm_medium: [] | [string];
+  utm_source: string;
+  utm_term: [] | [string];
+  utm_campaign: [] | [string];
 }
 export interface PageViewClient {
   os: string;
@@ -182,6 +196,7 @@ export interface SetPageView {
   referrer: [] | [string];
   time_zone: string;
   session_id: string;
+  campaign: [] | [PageViewCampaign];
   href: string;
   satellite_id: Principal;
   device: PageViewDevice;
@@ -245,6 +260,7 @@ export interface _SERVICE {
   http_request_update: ActorMethod<[HttpRequest], HttpResponse>;
   list_controllers: ActorMethod<[], Array<[Principal, Controller]>>;
   list_satellite_configs: ActorMethod<[], Array<[Principal, OrbiterSatelliteConfig]>>;
+  memory_size: ActorMethod<[], MemorySize>;
   set_controllers: ActorMethod<[SetControllersArgs], Array<[Principal, Controller]>>;
   set_page_view: ActorMethod<[AnalyticKey, SetPageView], Result>;
   set_page_views: ActorMethod<[Array<[AnalyticKey, SetPageView]>], Result_1>;

--- a/packages/admin/declarations/orbiter/orbiter.factory.certified.did.js
+++ b/packages/admin/declarations/orbiter/orbiter.factory.certified.did.js
@@ -33,6 +33,13 @@ export const idlFactory = ({IDL}) => {
     device: IDL.Opt(IDL.Text),
     browser: IDL.Text
   });
+  const PageViewCampaign = IDL.Record({
+    utm_content: IDL.Opt(IDL.Text),
+    utm_medium: IDL.Opt(IDL.Text),
+    utm_source: IDL.Text,
+    utm_term: IDL.Opt(IDL.Text),
+    utm_campaign: IDL.Opt(IDL.Text)
+  });
   const PageViewDevice = IDL.Record({
     inner_height: IDL.Nat16,
     screen_height: IDL.Opt(IDL.Nat16),
@@ -46,6 +53,7 @@ export const idlFactory = ({IDL}) => {
     referrer: IDL.Opt(IDL.Text),
     time_zone: IDL.Text,
     session_id: IDL.Text,
+    campaign: IDL.Opt(PageViewCampaign),
     href: IDL.Text,
     created_at: IDL.Nat64,
     satellite_id: IDL.Principal,
@@ -96,6 +104,8 @@ export const idlFactory = ({IDL}) => {
   const AnalyticsTop10PageViews = IDL.Record({
     referrers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)),
     pages: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)),
+    utm_campaigns: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32))),
+    utm_sources: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32))),
     time_zones: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)))
   });
   const NavigationType = IDL.Variant({
@@ -178,6 +188,7 @@ export const idlFactory = ({IDL}) => {
     created_at: IDL.Nat64,
     version: IDL.Opt(IDL.Nat64)
   });
+  const MemorySize = IDL.Record({stable: IDL.Nat64, heap: IDL.Nat64});
   const SetController = IDL.Record({
     metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     scope: ControllerScope,
@@ -194,6 +205,7 @@ export const idlFactory = ({IDL}) => {
     referrer: IDL.Opt(IDL.Text),
     time_zone: IDL.Text,
     session_id: IDL.Text,
+    campaign: IDL.Opt(PageViewCampaign),
     href: IDL.Text,
     satellite_id: IDL.Principal,
     device: PageViewDevice,
@@ -262,6 +274,7 @@ export const idlFactory = ({IDL}) => {
       [IDL.Vec(IDL.Tuple(IDL.Principal, OrbiterSatelliteConfig))],
       []
     ),
+    memory_size: IDL.Func([], [MemorySize], []),
     set_controllers: IDL.Func(
       [SetControllersArgs],
       [IDL.Vec(IDL.Tuple(IDL.Principal, Controller))],

--- a/packages/admin/declarations/orbiter/orbiter.factory.did.js
+++ b/packages/admin/declarations/orbiter/orbiter.factory.did.js
@@ -33,6 +33,13 @@ export const idlFactory = ({IDL}) => {
     device: IDL.Opt(IDL.Text),
     browser: IDL.Text
   });
+  const PageViewCampaign = IDL.Record({
+    utm_content: IDL.Opt(IDL.Text),
+    utm_medium: IDL.Opt(IDL.Text),
+    utm_source: IDL.Text,
+    utm_term: IDL.Opt(IDL.Text),
+    utm_campaign: IDL.Opt(IDL.Text)
+  });
   const PageViewDevice = IDL.Record({
     inner_height: IDL.Nat16,
     screen_height: IDL.Opt(IDL.Nat16),
@@ -46,6 +53,7 @@ export const idlFactory = ({IDL}) => {
     referrer: IDL.Opt(IDL.Text),
     time_zone: IDL.Text,
     session_id: IDL.Text,
+    campaign: IDL.Opt(PageViewCampaign),
     href: IDL.Text,
     created_at: IDL.Nat64,
     satellite_id: IDL.Principal,
@@ -96,6 +104,8 @@ export const idlFactory = ({IDL}) => {
   const AnalyticsTop10PageViews = IDL.Record({
     referrers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)),
     pages: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)),
+    utm_campaigns: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32))),
+    utm_sources: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32))),
     time_zones: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)))
   });
   const NavigationType = IDL.Variant({
@@ -178,6 +188,7 @@ export const idlFactory = ({IDL}) => {
     created_at: IDL.Nat64,
     version: IDL.Opt(IDL.Nat64)
   });
+  const MemorySize = IDL.Record({stable: IDL.Nat64, heap: IDL.Nat64});
   const SetController = IDL.Record({
     metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     scope: ControllerScope,
@@ -194,6 +205,7 @@ export const idlFactory = ({IDL}) => {
     referrer: IDL.Opt(IDL.Text),
     time_zone: IDL.Text,
     session_id: IDL.Text,
+    campaign: IDL.Opt(PageViewCampaign),
     href: IDL.Text,
     satellite_id: IDL.Principal,
     device: PageViewDevice,
@@ -278,6 +290,7 @@ export const idlFactory = ({IDL}) => {
       [IDL.Vec(IDL.Tuple(IDL.Principal, OrbiterSatelliteConfig))],
       ['query']
     ),
+    memory_size: IDL.Func([], [MemorySize], ['query']),
     set_controllers: IDL.Func(
       [SetControllersArgs],
       [IDL.Vec(IDL.Tuple(IDL.Principal, Controller))],

--- a/packages/admin/declarations/orbiter/orbiter.factory.did.mjs
+++ b/packages/admin/declarations/orbiter/orbiter.factory.did.mjs
@@ -33,6 +33,13 @@ export const idlFactory = ({IDL}) => {
     device: IDL.Opt(IDL.Text),
     browser: IDL.Text
   });
+  const PageViewCampaign = IDL.Record({
+    utm_content: IDL.Opt(IDL.Text),
+    utm_medium: IDL.Opt(IDL.Text),
+    utm_source: IDL.Text,
+    utm_term: IDL.Opt(IDL.Text),
+    utm_campaign: IDL.Opt(IDL.Text)
+  });
   const PageViewDevice = IDL.Record({
     inner_height: IDL.Nat16,
     screen_height: IDL.Opt(IDL.Nat16),
@@ -46,6 +53,7 @@ export const idlFactory = ({IDL}) => {
     referrer: IDL.Opt(IDL.Text),
     time_zone: IDL.Text,
     session_id: IDL.Text,
+    campaign: IDL.Opt(PageViewCampaign),
     href: IDL.Text,
     created_at: IDL.Nat64,
     satellite_id: IDL.Principal,
@@ -96,6 +104,8 @@ export const idlFactory = ({IDL}) => {
   const AnalyticsTop10PageViews = IDL.Record({
     referrers: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)),
     pages: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)),
+    utm_campaigns: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32))),
+    utm_sources: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32))),
     time_zones: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat32)))
   });
   const NavigationType = IDL.Variant({
@@ -178,6 +188,7 @@ export const idlFactory = ({IDL}) => {
     created_at: IDL.Nat64,
     version: IDL.Opt(IDL.Nat64)
   });
+  const MemorySize = IDL.Record({stable: IDL.Nat64, heap: IDL.Nat64});
   const SetController = IDL.Record({
     metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     scope: ControllerScope,
@@ -194,6 +205,7 @@ export const idlFactory = ({IDL}) => {
     referrer: IDL.Opt(IDL.Text),
     time_zone: IDL.Text,
     session_id: IDL.Text,
+    campaign: IDL.Opt(PageViewCampaign),
     href: IDL.Text,
     satellite_id: IDL.Principal,
     device: PageViewDevice,
@@ -278,6 +290,7 @@ export const idlFactory = ({IDL}) => {
       [IDL.Vec(IDL.Tuple(IDL.Principal, OrbiterSatelliteConfig))],
       ['query']
     ),
+    memory_size: IDL.Func([], [MemorySize], ['query']),
     set_controllers: IDL.Func(
       [SetControllersArgs],
       [IDL.Vec(IDL.Tuple(IDL.Principal, Controller))],

--- a/packages/admin/declarations/satellite/satellite.did.d.ts
+++ b/packages/admin/declarations/satellite/satellite.did.d.ts
@@ -143,6 +143,10 @@ export interface ListResults_1 {
   items_length: bigint;
 }
 export type Memory = {Heap: null} | {Stable: null};
+export interface MemorySize {
+  stable: bigint;
+  heap: bigint;
+}
 export type Permission = {Controllers: null} | {Private: null} | {Public: null} | {Managed: null};
 export interface RateConfig {
   max_tokens: bigint;
@@ -270,6 +274,7 @@ export interface _SERVICE {
   list_custom_domains: ActorMethod<[], Array<[string, CustomDomain]>>;
   list_docs: ActorMethod<[string, ListParams], ListResults_1>;
   list_rules: ActorMethod<[CollectionType], Array<[string, Rule]>>;
+  memory_size: ActorMethod<[], MemorySize>;
   set_auth_config: ActorMethod<[AuthenticationConfig], undefined>;
   set_controllers: ActorMethod<[SetControllersArgs], Array<[Principal, Controller]>>;
   set_custom_domain: ActorMethod<[string, [] | [string]], undefined>;

--- a/packages/admin/declarations/satellite/satellite.factory.certified.did.js
+++ b/packages/admin/declarations/satellite/satellite.factory.certified.did.js
@@ -208,6 +208,7 @@ export const idlFactory = ({IDL}) => {
     items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
     items_length: IDL.Nat64
   });
+  const MemorySize = IDL.Record({stable: IDL.Nat64, heap: IDL.Nat64});
   const SetController = IDL.Record({
     metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     scope: ControllerScope,
@@ -290,6 +291,7 @@ export const idlFactory = ({IDL}) => {
     list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], []),
     list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], []),
     list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], []),
+    memory_size: IDL.Func([], [MemorySize], []),
     set_auth_config: IDL.Func([AuthenticationConfig], [], []),
     set_controllers: IDL.Func(
       [SetControllersArgs],

--- a/packages/admin/declarations/satellite/satellite.factory.did.js
+++ b/packages/admin/declarations/satellite/satellite.factory.did.js
@@ -208,6 +208,7 @@ export const idlFactory = ({IDL}) => {
     items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
     items_length: IDL.Nat64
   });
+  const MemorySize = IDL.Record({stable: IDL.Nat64, heap: IDL.Nat64});
   const SetController = IDL.Record({
     metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     scope: ControllerScope,
@@ -290,6 +291,7 @@ export const idlFactory = ({IDL}) => {
     list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
     list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], ['query']),
     list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], ['query']),
+    memory_size: IDL.Func([], [MemorySize], ['query']),
     set_auth_config: IDL.Func([AuthenticationConfig], [], []),
     set_controllers: IDL.Func(
       [SetControllersArgs],

--- a/packages/admin/declarations/satellite/satellite.factory.did.mjs
+++ b/packages/admin/declarations/satellite/satellite.factory.did.mjs
@@ -208,6 +208,7 @@ export const idlFactory = ({IDL}) => {
     items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
     items_length: IDL.Nat64
   });
+  const MemorySize = IDL.Record({stable: IDL.Nat64, heap: IDL.Nat64});
   const SetController = IDL.Record({
     metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     scope: ControllerScope,
@@ -290,6 +291,7 @@ export const idlFactory = ({IDL}) => {
     list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
     list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], ['query']),
     list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], ['query']),
+    memory_size: IDL.Func([], [MemorySize], ['query']),
     set_auth_config: IDL.Func([AuthenticationConfig], [], []),
     set_controllers: IDL.Func(
       [SetControllersArgs],

--- a/packages/admin/src/api/orbiter.api.ts
+++ b/packages/admin/src/api/orbiter.api.ts
@@ -1,5 +1,9 @@
 import type {Principal} from '@dfinity/principal';
-import type {Controller, _SERVICE as OrbiterActor} from '../../declarations/orbiter/orbiter.did';
+import type {
+  Controller,
+  MemorySize,
+  _SERVICE as OrbiterActor
+} from '../../declarations/orbiter/orbiter.did';
 import type {OrbiterParameters} from '../types/actor.types';
 import {getDeprecatedOrbiterVersionActor, getOrbiterActor} from './actor.api';
 
@@ -18,4 +22,9 @@ export const listControllers = async ({
 }): Promise<[Principal, Controller][]> => {
   const actor: OrbiterActor = await getOrbiterActor(orbiter);
   return actor.list_controllers();
+};
+
+export const memorySize = async ({orbiter}: {orbiter: OrbiterParameters}): Promise<MemorySize> => {
+  const {memory_size} = await getOrbiterActor(orbiter);
+  return memory_size();
 };

--- a/packages/admin/src/api/satellite.api.ts
+++ b/packages/admin/src/api/satellite.api.ts
@@ -8,6 +8,7 @@ import type {
   Controller,
   CustomDomain,
   DbConfig,
+  MemorySize,
   Rule,
   _SERVICE as SatelliteActor,
   SetControllersArgs,
@@ -170,6 +171,15 @@ export const setCustomDomain = async ({
 }): Promise<void> => {
   const {set_custom_domain} = await getSatelliteActor(satellite);
   await set_custom_domain(domainName, toNullable(boundaryNodesId));
+};
+
+export const memorySize = async ({
+  satellite
+}: {
+  satellite: SatelliteParameters;
+}): Promise<MemorySize> => {
+  const {memory_size} = await getSatelliteActor(satellite);
+  return memory_size();
 };
 
 export const countDocs = async ({

--- a/packages/admin/src/services/orbiter.memory.services.ts
+++ b/packages/admin/src/services/orbiter.memory.services.ts
@@ -1,28 +1,12 @@
-import type {CanisterStatusResponse} from '@dfinity/ic-management';
-import {Principal} from '@dfinity/principal';
-import {assertNonNullish} from '@dfinity/utils';
-import {canisterStatus} from '../api/ic.api';
+import type {MemorySize} from '../../declarations/orbiter/orbiter.did';
+import {memorySize} from '../api/orbiter.api';
 import type {OrbiterParameters} from '../types/actor.types';
 
 /**
- * Retrieves the memory size of the Orbiter.
+ * Retrieves the stable and heap memory size of the Orbiter.
  * @param {Object} params - The parameters for the Orbiter.
  * @param {OrbiterParameters} params.orbiter - The Orbiter parameters.
- * @returns {Promise<Pick<CanisterStatusResponse, 'memory_size' | 'memory_metrics'>>} A promise that resolves to the memory size of the Orbiter.
+ * @returns {Promise<MemorySize>} A promise that resolves to the memory size of the Orbiter.
  */
-export const orbiterMemorySize = async ({
-  orbiter
-}: {
-  orbiter: OrbiterParameters;
-}): Promise<Pick<CanisterStatusResponse, 'memory_size' | 'memory_metrics'>> => {
-  const {orbiterId, ...actor} = orbiter;
-
-  assertNonNullish(orbiterId, 'No Orbiter ID provided.');
-
-  const {memory_size, memory_metrics} = await canisterStatus({
-    actor,
-    canisterId: Principal.fromText(orbiterId)
-  });
-
-  return {memory_size, memory_metrics};
-};
+export const orbiterMemorySize = (params: {orbiter: OrbiterParameters}): Promise<MemorySize> =>
+  memorySize(params);

--- a/packages/admin/src/services/satellite.memory.services.ts
+++ b/packages/admin/src/services/satellite.memory.services.ts
@@ -1,28 +1,13 @@
-import type {CanisterStatusResponse} from '@dfinity/ic-management';
-import {Principal} from '@dfinity/principal';
-import {assertNonNullish} from '@dfinity/utils';
-import {canisterStatus} from '../api/ic.api';
+import type {MemorySize} from '../../declarations/satellite/satellite.did';
+import {memorySize} from '../api/satellite.api';
 import type {SatelliteParameters} from '../types/actor.types';
 
 /**
- * Retrieves the memory size of a satellite.
+ * Retrieves the stable and heap memory size of a satellite.
  * @param {Object} params - The parameters for retrieving the memory size.
  * @param {SatelliteParameters} params.satellite - The satellite parameters.
- * @returns {Promise<Pick<CanisterStatusResponse, 'memory_size' | 'memory_metrics'>>} A promise that resolves to the memory size of the satellite.
+ * @returns {Promise<MemorySize>} A promise that resolves to the memory size of the satellite.
  */
-export const satelliteMemorySize = async ({
-  satellite
-}: {
+export const satelliteMemorySize = (params: {
   satellite: SatelliteParameters;
-}): Promise<Pick<CanisterStatusResponse, 'memory_size' | 'memory_metrics'>> => {
-  const {satelliteId, ...actor} = satellite;
-
-  assertNonNullish(satelliteId, 'No Satellite ID provided.');
-
-  const {memory_size, memory_metrics} = await canisterStatus({
-    actor,
-    canisterId: Principal.fromText(satelliteId)
-  });
-
-  return {memory_size, memory_metrics};
-};
+}): Promise<MemorySize> => memorySize(params);

--- a/packages/core/declarations/satellite/satellite.did.d.ts
+++ b/packages/core/declarations/satellite/satellite.did.d.ts
@@ -143,6 +143,10 @@ export interface ListResults_1 {
   items_length: bigint;
 }
 export type Memory = {Heap: null} | {Stable: null};
+export interface MemorySize {
+  stable: bigint;
+  heap: bigint;
+}
 export type Permission = {Controllers: null} | {Private: null} | {Public: null} | {Managed: null};
 export interface RateConfig {
   max_tokens: bigint;
@@ -270,6 +274,7 @@ export interface _SERVICE {
   list_custom_domains: ActorMethod<[], Array<[string, CustomDomain]>>;
   list_docs: ActorMethod<[string, ListParams], ListResults_1>;
   list_rules: ActorMethod<[CollectionType], Array<[string, Rule]>>;
+  memory_size: ActorMethod<[], MemorySize>;
   set_auth_config: ActorMethod<[AuthenticationConfig], undefined>;
   set_controllers: ActorMethod<[SetControllersArgs], Array<[Principal, Controller]>>;
   set_custom_domain: ActorMethod<[string, [] | [string]], undefined>;

--- a/packages/core/declarations/satellite/satellite.factory.certified.did.js
+++ b/packages/core/declarations/satellite/satellite.factory.certified.did.js
@@ -208,6 +208,7 @@ export const idlFactory = ({IDL}) => {
     items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
     items_length: IDL.Nat64
   });
+  const MemorySize = IDL.Record({stable: IDL.Nat64, heap: IDL.Nat64});
   const SetController = IDL.Record({
     metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     scope: ControllerScope,
@@ -290,6 +291,7 @@ export const idlFactory = ({IDL}) => {
     list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], []),
     list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], []),
     list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], []),
+    memory_size: IDL.Func([], [MemorySize], []),
     set_auth_config: IDL.Func([AuthenticationConfig], [], []),
     set_controllers: IDL.Func(
       [SetControllersArgs],

--- a/packages/core/declarations/satellite/satellite.factory.did.js
+++ b/packages/core/declarations/satellite/satellite.factory.did.js
@@ -208,6 +208,7 @@ export const idlFactory = ({IDL}) => {
     items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
     items_length: IDL.Nat64
   });
+  const MemorySize = IDL.Record({stable: IDL.Nat64, heap: IDL.Nat64});
   const SetController = IDL.Record({
     metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     scope: ControllerScope,
@@ -290,6 +291,7 @@ export const idlFactory = ({IDL}) => {
     list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
     list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], ['query']),
     list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], ['query']),
+    memory_size: IDL.Func([], [MemorySize], ['query']),
     set_auth_config: IDL.Func([AuthenticationConfig], [], []),
     set_controllers: IDL.Func(
       [SetControllersArgs],

--- a/packages/core/declarations/satellite/satellite.factory.did.mjs
+++ b/packages/core/declarations/satellite/satellite.factory.did.mjs
@@ -208,6 +208,7 @@ export const idlFactory = ({IDL}) => {
     items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
     items_length: IDL.Nat64
   });
+  const MemorySize = IDL.Record({stable: IDL.Nat64, heap: IDL.Nat64});
   const SetController = IDL.Record({
     metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     scope: ControllerScope,
@@ -290,6 +291,7 @@ export const idlFactory = ({IDL}) => {
     list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
     list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], ['query']),
     list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], ['query']),
+    memory_size: IDL.Func([], [MemorySize], ['query']),
     set_auth_config: IDL.Func([AuthenticationConfig], [], []),
     set_controllers: IDL.Func(
       [SetControllersArgs],

--- a/packages/core/declarations/sputnik/sputnik.did.d.ts
+++ b/packages/core/declarations/sputnik/sputnik.did.d.ts
@@ -143,6 +143,10 @@ export interface ListResults_1 {
   items_length: bigint;
 }
 export type Memory = {Heap: null} | {Stable: null};
+export interface MemorySize {
+  stable: bigint;
+  heap: bigint;
+}
 export type Permission = {Controllers: null} | {Private: null} | {Public: null} | {Managed: null};
 export interface RateConfig {
   max_tokens: bigint;
@@ -270,6 +274,7 @@ export interface _SERVICE {
   list_custom_domains: ActorMethod<[], Array<[string, CustomDomain]>>;
   list_docs: ActorMethod<[string, ListParams], ListResults_1>;
   list_rules: ActorMethod<[CollectionType], Array<[string, Rule]>>;
+  memory_size: ActorMethod<[], MemorySize>;
   set_auth_config: ActorMethod<[AuthenticationConfig], undefined>;
   set_controllers: ActorMethod<[SetControllersArgs], Array<[Principal, Controller]>>;
   set_custom_domain: ActorMethod<[string, [] | [string]], undefined>;

--- a/packages/core/declarations/sputnik/sputnik.factory.certified.did.js
+++ b/packages/core/declarations/sputnik/sputnik.factory.certified.did.js
@@ -208,6 +208,7 @@ export const idlFactory = ({IDL}) => {
     items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
     items_length: IDL.Nat64
   });
+  const MemorySize = IDL.Record({stable: IDL.Nat64, heap: IDL.Nat64});
   const SetController = IDL.Record({
     metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     scope: ControllerScope,
@@ -290,6 +291,7 @@ export const idlFactory = ({IDL}) => {
     list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], []),
     list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], []),
     list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], []),
+    memory_size: IDL.Func([], [MemorySize], []),
     set_auth_config: IDL.Func([AuthenticationConfig], [], []),
     set_controllers: IDL.Func(
       [SetControllersArgs],

--- a/packages/core/declarations/sputnik/sputnik.factory.did.js
+++ b/packages/core/declarations/sputnik/sputnik.factory.did.js
@@ -208,6 +208,7 @@ export const idlFactory = ({IDL}) => {
     items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
     items_length: IDL.Nat64
   });
+  const MemorySize = IDL.Record({stable: IDL.Nat64, heap: IDL.Nat64});
   const SetController = IDL.Record({
     metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     scope: ControllerScope,
@@ -290,6 +291,7 @@ export const idlFactory = ({IDL}) => {
     list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
     list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], ['query']),
     list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], ['query']),
+    memory_size: IDL.Func([], [MemorySize], ['query']),
     set_auth_config: IDL.Func([AuthenticationConfig], [], []),
     set_controllers: IDL.Func(
       [SetControllersArgs],

--- a/packages/storage/declarations/satellite/satellite.did.d.ts
+++ b/packages/storage/declarations/satellite/satellite.did.d.ts
@@ -143,6 +143,10 @@ export interface ListResults_1 {
   items_length: bigint;
 }
 export type Memory = {Heap: null} | {Stable: null};
+export interface MemorySize {
+  stable: bigint;
+  heap: bigint;
+}
 export type Permission = {Controllers: null} | {Private: null} | {Public: null} | {Managed: null};
 export interface RateConfig {
   max_tokens: bigint;
@@ -270,6 +274,7 @@ export interface _SERVICE {
   list_custom_domains: ActorMethod<[], Array<[string, CustomDomain]>>;
   list_docs: ActorMethod<[string, ListParams], ListResults_1>;
   list_rules: ActorMethod<[CollectionType], Array<[string, Rule]>>;
+  memory_size: ActorMethod<[], MemorySize>;
   set_auth_config: ActorMethod<[AuthenticationConfig], undefined>;
   set_controllers: ActorMethod<[SetControllersArgs], Array<[Principal, Controller]>>;
   set_custom_domain: ActorMethod<[string, [] | [string]], undefined>;

--- a/packages/storage/declarations/satellite/satellite.factory.certified.did.js
+++ b/packages/storage/declarations/satellite/satellite.factory.certified.did.js
@@ -208,6 +208,7 @@ export const idlFactory = ({IDL}) => {
     items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
     items_length: IDL.Nat64
   });
+  const MemorySize = IDL.Record({stable: IDL.Nat64, heap: IDL.Nat64});
   const SetController = IDL.Record({
     metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     scope: ControllerScope,
@@ -290,6 +291,7 @@ export const idlFactory = ({IDL}) => {
     list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], []),
     list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], []),
     list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], []),
+    memory_size: IDL.Func([], [MemorySize], []),
     set_auth_config: IDL.Func([AuthenticationConfig], [], []),
     set_controllers: IDL.Func(
       [SetControllersArgs],

--- a/packages/storage/declarations/satellite/satellite.factory.did.js
+++ b/packages/storage/declarations/satellite/satellite.factory.did.js
@@ -208,6 +208,7 @@ export const idlFactory = ({IDL}) => {
     items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
     items_length: IDL.Nat64
   });
+  const MemorySize = IDL.Record({stable: IDL.Nat64, heap: IDL.Nat64});
   const SetController = IDL.Record({
     metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     scope: ControllerScope,
@@ -290,6 +291,7 @@ export const idlFactory = ({IDL}) => {
     list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
     list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], ['query']),
     list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], ['query']),
+    memory_size: IDL.Func([], [MemorySize], ['query']),
     set_auth_config: IDL.Func([AuthenticationConfig], [], []),
     set_controllers: IDL.Func(
       [SetControllersArgs],

--- a/packages/storage/declarations/satellite/satellite.factory.did.mjs
+++ b/packages/storage/declarations/satellite/satellite.factory.did.mjs
@@ -208,6 +208,7 @@ export const idlFactory = ({IDL}) => {
     items: IDL.Vec(IDL.Tuple(IDL.Text, Doc)),
     items_length: IDL.Nat64
   });
+  const MemorySize = IDL.Record({stable: IDL.Nat64, heap: IDL.Nat64});
   const SetController = IDL.Record({
     metadata: IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)),
     scope: ControllerScope,
@@ -290,6 +291,7 @@ export const idlFactory = ({IDL}) => {
     list_custom_domains: IDL.Func([], [IDL.Vec(IDL.Tuple(IDL.Text, CustomDomain))], ['query']),
     list_docs: IDL.Func([IDL.Text, ListParams], [ListResults_1], ['query']),
     list_rules: IDL.Func([CollectionType], [IDL.Vec(IDL.Tuple(IDL.Text, Rule))], ['query']),
+    memory_size: IDL.Func([], [MemorySize], ['query']),
     set_auth_config: IDL.Func([AuthenticationConfig], [], []),
     set_controllers: IDL.Func(
       [SetControllersArgs],


### PR DESCRIPTION
We need the custom memory size endpoints for the CLI used in GH Actions.