### PR TITLE
feat: compress HTML

### DIFF
--- a/packages/cli-tools/src/constants/deploy.constants.ts
+++ b/packages/cli-tools/src/constants/deploy.constants.ts
@@ -1,7 +1,7 @@
 export const DEPLOY_DEFAULT_SOURCE = 'build';
 export const DEPLOY_DEFAULT_IGNORE = [];
 export const DEPLOY_DEFAULT_ENCODING = [];
-export const DEPLOY_DEFAULT_GZIP = '**/*.+(css|js|mjs)';
+export const DEPLOY_DEFAULT_GZIP = '**/*.+(css|js|mjs|html)';
 
 export const IGNORE_OS_FILES = ['.ds_store', 'thumbs.db'];
 export const COLLECTION_DAPP = '#dapp';


### PR DESCRIPTION
# Motivation

We also want to serve HTML files on the web with gzip compression. This was pending because I never took the time to comebac to it as I though it was a tricky problem to resolve but actually, given that the CLI upload compressed files first, we can safely now gzip HTML as well.