### PR TITLE
feat: include all files option in pre-deploy

### DIFF
--- a/packages/cli-tools/src/types/deploy.ts
+++ b/packages/cli-tools/src/types/deploy.ts
@@ -52,10 +52,14 @@ export type DeployResultWithProposal =
       files: Pick<FileDetails, 'file'>[];
     };
 
-export interface DeployParams<T = UploadFile> {
+export interface PrepareDeployOptions {
+  assertSourceDirExists?: (source: string) => void;
+  includeAllFiles?: boolean;
+}
+
+export type DeployParams<T = UploadFile> = PrepareDeployOptions & {
   config: CliConfig;
   listAssets: ListAssets;
-  assertSourceDirExists?: (source: string) => void;
   assertMemory: () => Promise<void>;
   uploadFile: T;
-}
+};


### PR DESCRIPTION
When one submit a deploy proposal with clear, we need to submit all data not assert we only submit the differences because it's basically like a force all redeploy.