### PR TITLE
feat: redo sourceAbsolutePath for deploy

### DIFF
--- a/packages/cli-tools/src/commands/deploy.ts
+++ b/packages/cli-tools/src/commands/deploy.ts
@@ -73,17 +73,18 @@ export const deploy = async ({uploadFile, ...rest}: DeployParams): Promise<Deplo
     return {result: 'skipped'};
   }
 
-  const sourceFiles = prepareSourceFiles(prepareResult);
+  const {files, sourceAbsolutePath} = prepareResult;
+
+  const sourceFiles = prepareSourceFiles({files, sourceAbsolutePath});
 
   await uploadFiles({
     files: sourceFiles,
     uploadFile,
+    sourceAbsolutePath,
     collection: COLLECTION_DAPP
   });
 
   console.log(`\n🚀 Deploy complete!`);
-
-  const {files} = prepareResult;
 
   return {result: 'deployed', files};
 };
@@ -122,10 +123,12 @@ export const deployWithProposal = async ({
     return {result: 'skipped'};
   }
 
+  const {sourceAbsolutePath} = prepareResult;
+
   const sourceFiles = prepareSourceFiles(prepareResult);
 
   const result = await deployAndProposeChanges({
-    deploy: {uploadFile, files: sourceFiles, collection: COLLECTION_DAPP},
+    deploy: {uploadFile, files: sourceFiles, sourceAbsolutePath, collection: COLLECTION_DAPP},
     proposal: {
       ...restProposal,
       proposalType: {

--- a/packages/cli-tools/src/commands/upgrade.ts
+++ b/packages/cli-tools/src/commands/upgrade.ts
@@ -25,7 +25,7 @@ import type {DeploySatelliteWasmParams} from '../types/upgrade';
  * - `{ result: 'deployed', files, proposalId }` – Upload succeeded and proposal was auto-committed.
  */
 export const deploySatelliteWasmWithProposal = async ({
-  deploy: {uploadFile, assertMemory, filePath, fullPath, token},
+  deploy: {assertMemory, filePath, fullPath, token, ...restDeploy},
   proposal: {version, ...restProposal}
 }: {
   deploy: DeploySatelliteWasmParams;
@@ -47,7 +47,7 @@ export const deploySatelliteWasmWithProposal = async ({
   ];
 
   const result = await deployAndProposeChanges({
-    deploy: {uploadFile, files: sourceFiles, collection: COLLECTION_CDN},
+    deploy: {...restDeploy, files: sourceFiles, collection: COLLECTION_CDN},
     proposal: {
       ...restProposal,
       proposalType: {

--- a/packages/cli-tools/src/services/deploy.proposal.services.ts
+++ b/packages/cli-tools/src/services/deploy.proposal.services.ts
@@ -11,11 +11,12 @@ import {proposeChanges} from './proposals.services';
 import {uploadFiles} from './upload.services';
 
 export const deployAndProposeChanges = async ({
-  deploy: {uploadFile, files, collection},
+  deploy: {uploadFile, files, sourceAbsolutePath, collection},
   proposal: {proposalType, autoCommit, ...proposalRest}
 }: {
   deploy: Pick<DeployParams<UploadFileWithProposal>, 'uploadFile'> & {
     files: FileAndPaths[];
+    sourceAbsolutePath: string;
     collection: typeof COLLECTION_DAPP | typeof COLLECTION_CDN;
   };
   proposal: Omit<ProposeChangesParams, 'executeChanges'>;
@@ -29,6 +30,7 @@ export const deployAndProposeChanges = async ({
 
     await uploadFiles({
       files,
+      sourceAbsolutePath,
       collection,
       uploadFile: uploadWithProposalId
     });

--- a/packages/cli-tools/src/types/upgrade.ts
+++ b/packages/cli-tools/src/types/upgrade.ts
@@ -5,4 +5,4 @@ export type DeploySatelliteWasmParams = Pick<
   'assertMemory' | 'uploadFile'
 > &
   FilePaths &
-  Pick<FileDetails, 'token'>;
+  Pick<FileDetails, 'token'> & {sourceAbsolutePath: string};


### PR DESCRIPTION
> ❯ node /Users/daviddalbusco/projects/juno/cli deploy --mode development --clear --no-apply
>   ✔ Uploading /index.html
>   ✔ Uploading /index.html
  
  
  We do not want to display twice the full path but, want to diplsay the difference so we need to print the relative path to source (one is .html.gz)