### PR TITLE
feat: pass description as well for deploying assets with proposals

### DIFF
--- a/packages/cli-tools/src/commands/upgrade.ts
+++ b/packages/cli-tools/src/commands/upgrade.ts
@@ -25,7 +25,7 @@ import type {DeploySatelliteWasmParams} from '../types/upgrade';
  * - `{ result: 'deployed', files, proposalId }` – Upload succeeded and proposal was auto-committed.
  */
 export const deploySatelliteWasmWithProposal = async ({
-  deploy: {assertMemory, filePath, fullPath, token, ...restDeploy},
+  deploy: {assertMemory, filePath, fullPath, token, description, ...restDeploy},
   proposal: {version, ...restProposal}
 }: {
   deploy: DeploySatelliteWasmParams;
@@ -37,7 +37,8 @@ export const deploySatelliteWasmWithProposal = async ({
     {
       file: {
         file: filePath,
-        token
+        token,
+        description
       },
       paths: {
         filePath,

--- a/packages/cli-tools/src/commands/upgrade.ts
+++ b/packages/cli-tools/src/commands/upgrade.ts
@@ -25,7 +25,7 @@ import type {DeploySatelliteWasmParams} from '../types/upgrade';
  * - `{ result: 'deployed', files, proposalId }` – Upload succeeded and proposal was auto-committed.
  */
 export const deploySatelliteWasmWithProposal = async ({
-  deploy: {assertMemory, filePath, fullPath, token, description, ...restDeploy},
+  deploy: {assertMemory, filePath, fullPath, ...restDeploy},
   proposal: {version, ...restProposal}
 }: {
   deploy: DeploySatelliteWasmParams;
@@ -36,9 +36,7 @@ export const deploySatelliteWasmWithProposal = async ({
   const sourceFiles: FileAndPaths[] = [
     {
       file: {
-        file: filePath,
-        token,
-        description
+        file: filePath
       },
       paths: {
         filePath,

--- a/packages/cli-tools/src/services/upload.services.ts
+++ b/packages/cli-tools/src/services/upload.services.ts
@@ -1,4 +1,4 @@
-import {isNullish, nonNullish} from '@dfinity/utils';
+import {isNullish, nonNullish, notEmptyString} from '@dfinity/utils';
 import {Blob} from 'buffer';
 import Listr from 'listr';
 import {readFile} from 'node:fs/promises';
@@ -105,6 +105,8 @@ const uploadFileToStorage = async ({
       ...(file.mime === undefined ? [] : ([['Content-Type', file.mime]] as Array<[string, string]>))
     ],
     encoding: file.encoding,
-    ...(nonNullish(file.token) && {token: file.token})
+    ...(nonNullish(file.token) && notEmptyString(file.token) && {token: file.token}),
+    ...(nonNullish(file.description) &&
+      notEmptyString(file.description) && {description: file.description})
   });
 };

--- a/packages/cli-tools/src/services/upload.services.ts
+++ b/packages/cli-tools/src/services/upload.services.ts
@@ -90,12 +90,17 @@ const uploadFileToStorage = async ({
   file,
   fullPath,
   collection,
-  filePath
+  filePath,
+  token,
+  description
 }: {
   file: FileDetails;
   uploadFile: UploadFile;
   filePath: string;
-} & Pick<UploadFileStorage, 'fullPath' | 'collection'>): Promise<void> => {
+} & Pick<
+  UploadFileStorage,
+  'fullPath' | 'collection' | 'token' | 'description'
+>): Promise<void> => {
   await uploadFile({
     filename: basename(filePath),
     fullPath,
@@ -105,8 +110,7 @@ const uploadFileToStorage = async ({
       ...(file.mime === undefined ? [] : ([['Content-Type', file.mime]] as Array<[string, string]>))
     ],
     encoding: file.encoding,
-    ...(nonNullish(file.token) && notEmptyString(file.token) && {token: file.token}),
-    ...(nonNullish(file.description) &&
-      notEmptyString(file.description) && {description: file.description})
+    ...(nonNullish(token) && notEmptyString(token) && {token}),
+    ...(nonNullish(description) && notEmptyString(description) && {description})
   });
 };

--- a/packages/cli-tools/src/types/deploy.ts
+++ b/packages/cli-tools/src/types/deploy.ts
@@ -5,13 +5,13 @@ export type MimeType = string;
 
 export type FileExtension = string;
 
-export type FileDetails = Pick<UploadFileStorage, 'token' | 'description'> & {
+export interface FileDetails {
   file: string;
   // e.g. for index.js.gz -> index.js
   alternateFile?: string;
   encoding?: ENCODING_TYPE;
   mime?: MimeType;
-};
+}
 
 export type FilePaths = Required<Pick<UploadFileStorage, 'fullPath'>> & {
   filePath: string;

--- a/packages/cli-tools/src/types/deploy.ts
+++ b/packages/cli-tools/src/types/deploy.ts
@@ -5,7 +5,7 @@ export type MimeType = string;
 
 export type FileExtension = string;
 
-export type FileDetails = Pick<UploadFileStorage, 'token'> & {
+export type FileDetails = Pick<UploadFileStorage, 'token' | 'description'> & {
   file: string;
   // e.g. for index.js.gz -> index.js
   alternateFile?: string;

--- a/packages/cli-tools/src/types/upgrade.ts
+++ b/packages/cli-tools/src/types/upgrade.ts
@@ -1,8 +1,7 @@
-import type {DeployParams, FileDetails, FilePaths, UploadFileWithProposal} from './deploy';
+import type {DeployParams, FilePaths, UploadFileWithProposal} from './deploy';
 
 export type DeploySatelliteWasmParams = Pick<
   DeployParams<UploadFileWithProposal>,
   'assertMemory' | 'uploadFile'
 > &
-  FilePaths &
-  Pick<FileDetails, 'token' | 'description'> & {sourceAbsolutePath: string};
+  FilePaths & {sourceAbsolutePath: string};

--- a/packages/cli-tools/src/types/upgrade.ts
+++ b/packages/cli-tools/src/types/upgrade.ts
@@ -5,4 +5,4 @@ export type DeploySatelliteWasmParams = Pick<
   'assertMemory' | 'uploadFile'
 > &
   FilePaths &
-  Pick<FileDetails, 'token'> & {sourceAbsolutePath: string};
+  Pick<FileDetails, 'token' | 'description'> & {sourceAbsolutePath: string};


### PR DESCRIPTION
On one hand, pass the description this way we can use it to save the reference proposal / change ID, on the other, remove token from the main entry and use it only where needed, on upload file.