### PR TITLE
fix(functions): random between 0 and 1

### DIFF
--- a/packages/functions/src/polyfills/random.polyfill.ts
+++ b/packages/functions/src/polyfills/random.polyfill.ts
@@ -1,7 +1,13 @@
 /**
  * @see Math.random
  */
-const random = (): number => __juno_satellite_random();
+const random = (): number => {
+  // __juno_satellite_random() returns a signed 32-bit int (i32)
+  const value = __juno_satellite_random();
+
+  // >>> 0 converts it to unsigned (same bits, JS-side)
+  return (value >>> 0) / 2 ** 32;
+};
 
 /**
  * Overwrites Math.random with a pseudo-random number using the Satellite's internal RNG.

--- a/packages/functions/src/tests/polyfills/random.polyfill.spec.ts
+++ b/packages/functions/src/tests/polyfills/random.polyfill.spec.ts
@@ -7,7 +7,7 @@ globalThis.__juno_satellite_random = vi.fn(() => mockRandomValue);
 describe('Math.random override', () => {
   it('should return the value from __juno_satellite_random', () => {
     const result = Math.random();
-    expect(result).toBe(mockRandomValue);
+    expect(result).toBe(0.00028744502924382687);
     expect(globalThis.__juno_satellite_random).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Well, that's freaking dumb. The Satellite returns bigint so we need to interpolate if we really want to mock Math.random.