### PR TITLE
feat(libs): revert "build(libs): bump zod v4 (#447)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -815,14 +815,14 @@
       }
     },
     "node_modules/@dfinity/zod-schemas": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/zod-schemas/-/zod-schemas-2.0.0.tgz",
-      "integrity": "sha512-mvgiYCwGXgT+iFdvTFWh5Da0HCsF8VIFTIsY+uQifaf4duc3+K1nb16O7+tCzFD7Vs4ZmjImCNi+lO5GqjplNA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/zod-schemas/-/zod-schemas-1.0.0.tgz",
+      "integrity": "sha512-5ApkpRO8hqTb7B9GH4H8FljY/r6hh3zpA/HFeeozIHieyebAzB748+4T9/oL6T7udkvlfWPMulbmjSHerm3B9A==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
         "@dfinity/principal": "^2.0.0",
-        "zod": "^4"
+        "zod": "^3.25"
       }
     },
     "node_modules/@esbuild-plugins/node-modules-polyfill": {
@@ -9024,9 +9024,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
-      "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+      "version": "3.25.71",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.71.tgz",
+      "integrity": "sha512-BsBc/NPk7h8WsUWYWYL+BajcJPY8YhjelaWu2NMLuzgraKAz4Lb4/6K11g9jpuDetjMiqhZ6YaexFLOC0Ogi3Q==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -9046,7 +9046,7 @@
         "@dfinity/utils": "^2",
         "@junobuild/config": "*",
         "semver": "7.*",
-        "zod": "^4"
+        "zod": "^3.25"
       }
     },
     "packages/analytics": {
@@ -9168,8 +9168,8 @@
       "version": "0.4.1",
       "license": "MIT",
       "peerDependencies": {
-        "@dfinity/zod-schemas": "^2",
-        "zod": "^4"
+        "@dfinity/zod-schemas": "^1.0.0",
+        "zod": "^3.25"
       }
     },
     "packages/config-loader": {
@@ -9262,7 +9262,7 @@
         "@dfinity/identity": "^2.3.0",
         "@dfinity/principal": "^2.3.0",
         "@dfinity/utils": "^2",
-        "zod": "^4"
+        "zod": "^3.25"
       }
     },
     "packages/storage": {
@@ -9742,9 +9742,9 @@
       "requires": {}
     },
     "@dfinity/zod-schemas": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/zod-schemas/-/zod-schemas-2.0.0.tgz",
-      "integrity": "sha512-mvgiYCwGXgT+iFdvTFWh5Da0HCsF8VIFTIsY+uQifaf4duc3+K1nb16O7+tCzFD7Vs4ZmjImCNi+lO5GqjplNA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/zod-schemas/-/zod-schemas-1.0.0.tgz",
+      "integrity": "sha512-5ApkpRO8hqTb7B9GH4H8FljY/r6hh3zpA/HFeeozIHieyebAzB748+4T9/oL6T7udkvlfWPMulbmjSHerm3B9A==",
       "peer": true,
       "requires": {}
     },
@@ -14928,9 +14928,9 @@
       "peer": true
     },
     "zod": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
-      "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+      "version": "3.25.71",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.71.tgz",
+      "integrity": "sha512-BsBc/NPk7h8WsUWYWYL+BajcJPY8YhjelaWu2NMLuzgraKAz4Lb4/6K11g9jpuDetjMiqhZ6YaexFLOC0Ogi3Q==",
       "peer": true
     }
   }

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -58,6 +58,6 @@
     "@dfinity/utils": "^2",
     "@junobuild/config": "*",
     "semver": "7.*",
-    "zod": "^4"
+    "zod": "^3.25"
   }
 }

--- a/packages/admin/src/services/package.services.ts
+++ b/packages/admin/src/services/package.services.ts
@@ -1,7 +1,7 @@
 import type {Principal} from '@dfinity/principal';
 import {isNullish} from '@dfinity/utils';
 import {type JunoPackage, JunoPackageSchema} from '@junobuild/config';
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {canisterMetadata} from '../api/ic.api';
 import type {ActorParameters} from '../types/actor.types';
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://juno.build",
   "peerDependencies": {
-    "@dfinity/zod-schemas": "^2",
-    "zod": "^4"
+    "@dfinity/zod-schemas": "^1.0.0",
+    "zod": "^3.25"
   }
 }

--- a/packages/config/src/console/console.config.ts
+++ b/packages/config/src/console/console.config.ts
@@ -1,5 +1,5 @@
 import {type PrincipalText, PrincipalTextSchema} from '@dfinity/zod-schemas';
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {type StorageConfig, StorageConfigSchema} from '../shared/storage.config';
 import {type CliConfig, CliConfigSchema} from '../types/cli.config';
 import {type JunoConfigMode, JunoConfigModeSchema} from '../types/juno.env';

--- a/packages/config/src/module/module.settings.ts
+++ b/packages/config/src/module/module.settings.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 /**
  * @see ModuleLogVisibility

--- a/packages/config/src/pkg/juno.package.ts
+++ b/packages/config/src/pkg/juno.package.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 /**
  * @see JunoPackageDependencies

--- a/packages/config/src/satellite/dev/juno.dev.config.ts
+++ b/packages/config/src/satellite/dev/juno.dev.config.ts
@@ -1,5 +1,5 @@
 import {type PrincipalText, PrincipalTextSchema} from '@dfinity/zod-schemas';
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {type Rule, RuleSchema} from '../types/rules';
 
 /**

--- a/packages/config/src/satellite/mainnet/configs/assertions.config.ts
+++ b/packages/config/src/satellite/mainnet/configs/assertions.config.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 /**
  * @see SatelliteAssertions

--- a/packages/config/src/satellite/mainnet/configs/authentication.config.ts
+++ b/packages/config/src/satellite/mainnet/configs/authentication.config.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 /**
  * @see AuthenticationConfigInternetIdentity

--- a/packages/config/src/satellite/mainnet/configs/datastore.config.ts
+++ b/packages/config/src/satellite/mainnet/configs/datastore.config.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {type MaxMemorySizeConfig, MaxMemorySizeConfigSchema} from '../../../shared/feature.config';
 
 /**

--- a/packages/config/src/satellite/mainnet/configs/emulator.config.ts
+++ b/packages/config/src/satellite/mainnet/configs/emulator.config.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 const EmulatorPortsSchema = z.strictObject({
   /**

--- a/packages/config/src/satellite/mainnet/configs/orbiter.config.ts
+++ b/packages/config/src/satellite/mainnet/configs/orbiter.config.ts
@@ -1,5 +1,5 @@
 import {type PrincipalText, PrincipalTextSchema} from '@dfinity/zod-schemas';
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {type JunoConfigMode, JunoConfigModeSchema} from '../../../types/juno.env';
 import type {Either} from '../../../types/utility.types';
 import {StrictPrincipalTextSchema} from '../../../utils/principal.utils';

--- a/packages/config/src/satellite/mainnet/configs/satellite.config.ts
+++ b/packages/config/src/satellite/mainnet/configs/satellite.config.ts
@@ -1,5 +1,5 @@
 import {type PrincipalText, PrincipalTextSchema} from '@dfinity/zod-schemas';
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {type ModuleSettings, ModuleSettingsSchema} from '../../../module/module.settings';
 import {type StorageConfig, StorageConfigSchema} from '../../../shared/storage.config';
 import type {CliConfig} from '../../../types/cli.config';

--- a/packages/config/src/satellite/mainnet/juno.config.ts
+++ b/packages/config/src/satellite/mainnet/juno.config.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {type EmulatorConfig, EmulatorConfigSchema} from './configs/emulator.config';
 import {type OrbiterConfig, OrbiterConfigSchema} from './configs/orbiter.config';
 import {type SatelliteConfig, SatelliteConfigOptionsSchema} from './configs/satellite.config';

--- a/packages/config/src/satellite/types/rules.ts
+++ b/packages/config/src/satellite/types/rules.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 /**
  * @see PermissionText

--- a/packages/config/src/shared/feature.config.ts
+++ b/packages/config/src/shared/feature.config.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 /**
  * @see MaxMemorySizeConfig

--- a/packages/config/src/shared/storage.config.ts
+++ b/packages/config/src/shared/storage.config.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {type MaxMemorySizeConfig, MaxMemorySizeConfigSchema} from './feature.config';
 
 /**

--- a/packages/config/src/types/cli.config.ts
+++ b/packages/config/src/types/cli.config.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {type EncodingType, EncodingTypeSchema} from './encoding';
 
 /**

--- a/packages/config/src/types/encoding.ts
+++ b/packages/config/src/types/encoding.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 /**
  * see EncodingType

--- a/packages/config/src/types/juno.env.ts
+++ b/packages/config/src/types/juno.env.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 /**
  * @see JunoConfigMode

--- a/packages/config/src/utils/principal.utils.ts
+++ b/packages/config/src/utils/principal.utils.ts
@@ -1,5 +1,5 @@
 import {PrincipalTextSchema} from '@dfinity/zod-schemas';
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 /**
  * Ensures reliable validation of PrincipalTextSchema inside z.record.

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -51,6 +51,6 @@
     "@dfinity/identity": "^2.3.0",
     "@dfinity/principal": "^2.3.0",
     "@dfinity/utils": "^2",
-    "zod": "^4"
+    "zod": "^3.25"
   }
 }

--- a/packages/functions/src/hooks/assertions.ts
+++ b/packages/functions/src/hooks/assertions.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {createFunctionSchema} from '../utils/zod.utils';
 import {type Collections, CollectionsSchema} from './schemas/collections';
 import {type AssertFunction, AssertFunctionSchema} from './schemas/context';

--- a/packages/functions/src/hooks/hooks.ts
+++ b/packages/functions/src/hooks/hooks.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {createFunctionSchema} from '../utils/zod.utils';
 import {type Collections, CollectionsSchema} from './schemas/collections';
 import {type RunFunction, RunFunctionSchema} from './schemas/context';

--- a/packages/functions/src/hooks/schemas/collections.ts
+++ b/packages/functions/src/hooks/schemas/collections.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import type {Collection} from '../../schemas/satellite';
 
 /**

--- a/packages/functions/src/hooks/schemas/context.ts
+++ b/packages/functions/src/hooks/schemas/context.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {type RawUserId, RawUserIdSchema} from '../../schemas/satellite';
 import {createFunctionSchema} from '../../utils/zod.utils';
 

--- a/packages/functions/src/hooks/schemas/db/context.ts
+++ b/packages/functions/src/hooks/schemas/db/context.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {DocSchema, type OptionDoc} from '../../../schemas/db';
 import {type Collection, CollectionSchema, type Key, KeySchema} from '../../../schemas/satellite';
 import {type HookContext, HookContextSchema} from '../context';

--- a/packages/functions/src/hooks/schemas/db/payload.ts
+++ b/packages/functions/src/hooks/schemas/db/payload.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {
   type DelDoc,
   DelDocSchema,

--- a/packages/functions/src/hooks/schemas/satellite.env.ts
+++ b/packages/functions/src/hooks/schemas/satellite.env.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 /**
  * @see SatelliteEnv

--- a/packages/functions/src/hooks/schemas/storage/context.ts
+++ b/packages/functions/src/hooks/schemas/storage/context.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {AssetSchema, type Asset} from '../../../schemas/storage';
 import {HookContextSchema, type HookContext} from '../context';
 import {AssetAssertUploadSchema, type AssetAssertUpload} from './payload';

--- a/packages/functions/src/hooks/schemas/storage/payload.ts
+++ b/packages/functions/src/hooks/schemas/storage/payload.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {
   type Asset,
   AssetSchema,

--- a/packages/functions/src/ic-cdk/schemas/call.ts
+++ b/packages/functions/src/ic-cdk/schemas/call.ts
@@ -1,6 +1,6 @@
 import {IDL} from '@dfinity/candid';
 import type {Principal} from '@dfinity/principal';
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {PrincipalSchema, type RawPrincipal, RawPrincipalSchema} from '../../schemas/candid';
 
 /**

--- a/packages/functions/src/schemas/candid.ts
+++ b/packages/functions/src/schemas/candid.ts
@@ -1,5 +1,5 @@
 import {Principal as CandidPrincipal} from '@dfinity/principal';
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 /**
  * A schema that validates a value is an Uint8Array.

--- a/packages/functions/src/schemas/db.ts
+++ b/packages/functions/src/schemas/db.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {Uint8ArraySchema} from './candid';
 import {
   type Description,

--- a/packages/functions/src/schemas/list.ts
+++ b/packages/functions/src/schemas/list.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {
   type Description,
   type Key,

--- a/packages/functions/src/schemas/satellite.ts
+++ b/packages/functions/src/schemas/satellite.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {PrincipalSchema, RawPrincipalSchema} from './candid';
 
 /**

--- a/packages/functions/src/schemas/storage.ts
+++ b/packages/functions/src/schemas/storage.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {Uint8ArraySchema} from './candid';
 import {
   type Collection,

--- a/packages/functions/src/sdk/schemas/collections.ts
+++ b/packages/functions/src/sdk/schemas/collections.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 /**
  * @see Memory

--- a/packages/functions/src/sdk/schemas/controllers.ts
+++ b/packages/functions/src/sdk/schemas/controllers.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {RawPrincipalSchema} from '../../schemas/candid';
 import {
   type RawUserId,

--- a/packages/functions/src/sdk/schemas/params.ts
+++ b/packages/functions/src/sdk/schemas/params.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {type ListParams, ListParamsSchema} from '../../schemas/list';
 import {
   type Collection,

--- a/packages/functions/src/sdk/schemas/storage.ts
+++ b/packages/functions/src/sdk/schemas/storage.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {type RawUserId, type UserId, RawUserIdSchema, UserIdSchema} from '../../schemas/satellite';
 import {
   type AssetEncoding,

--- a/packages/functions/src/tests/hooks/schemas/context.spec.ts
+++ b/packages/functions/src/tests/hooks/schemas/context.spec.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {
   AssertFunctionSchema,
   HookContextSchema,

--- a/packages/functions/src/tests/hooks/schemas/db/context.spec.ts
+++ b/packages/functions/src/tests/hooks/schemas/db/context.spec.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {
   AssertDeleteDocContextSchema,
   AssertSetDocContextSchema,

--- a/packages/functions/src/tests/schemas/db.spec.ts
+++ b/packages/functions/src/tests/schemas/db.spec.ts
@@ -1,5 +1,5 @@
 import {Principal} from '@dfinity/principal';
-import {ZodError} from 'zod';
+import {ZodError} from 'zod/v4';
 import {
   DelDocSchema,
   DocSchema,

--- a/packages/functions/src/tests/schemas/list.spec.ts
+++ b/packages/functions/src/tests/schemas/list.spec.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {
   ListMatcherSchema,
   ListOrderFieldSchema,

--- a/packages/functions/src/tests/schemas/storage.spec.ts
+++ b/packages/functions/src/tests/schemas/storage.spec.ts
@@ -1,5 +1,5 @@
 import {Principal} from '@dfinity/principal';
-import {ZodError} from 'zod';
+import {ZodError} from 'zod/v4';
 import {
   type Asset,
   AssetEncodingSchema,

--- a/packages/functions/src/tests/sdk/db.sdk.spec.ts
+++ b/packages/functions/src/tests/sdk/db.sdk.spec.ts
@@ -1,5 +1,5 @@
 import {Principal} from '@dfinity/principal';
-import {ZodError} from 'zod';
+import {ZodError} from 'zod/v4';
 import {
   countCollectionDocsStore,
   countDocsStore,

--- a/packages/functions/src/tests/sdk/schemas/storage.spec.ts
+++ b/packages/functions/src/tests/sdk/schemas/storage.spec.ts
@@ -1,5 +1,5 @@
 import {Principal} from '@dfinity/principal';
-import {ZodError} from 'zod';
+import {ZodError} from 'zod/v4';
 import {
   CountAssetsStoreParamsSchema,
   CountCollectionAssetsStoreParamsSchema,

--- a/packages/functions/src/tests/sdk/storage.sdk.spec.ts
+++ b/packages/functions/src/tests/sdk/storage.sdk.spec.ts
@@ -1,5 +1,5 @@
 import {Principal} from '@dfinity/principal';
-import {ZodError} from 'zod';
+import {ZodError} from 'zod/v4';
 import {
   CountAssetsStoreParams,
   CountCollectionAssetsStoreParams,

--- a/packages/functions/src/utils/zod.utils.ts
+++ b/packages/functions/src/utils/zod.utils.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 // TODO: Workaround source: https://github.com/colinhacks/zod/issues/4143#issuecomment-2845134912
 export const createFunctionSchema = <T extends z.core.$ZodFunction>(schema: T) =>


### PR DESCRIPTION
# Motivation

Third party dependencies of the OISY Wallet arent' compatible with Zod v4 lib. As a result, the OISY Wallet Signer should revert the dependency on Zod v4, as a result and to avoid conflicts, I should do the same...