### PR TITLE
feat(cli-tools): avoid re-uploading binary file

### DIFF
--- a/packages/cli-tools/src/services/deploy.prepare.services.ts
+++ b/packages/cli-tools/src/services/deploy.prepare.services.ts
@@ -109,6 +109,9 @@ const fileNeedUpload = async ({
   const sha256 = await computeSha256(effectiveFilePath);
 
   // Previously, comparing the SHA-256 hash of Gzip and Brotli files between Node.js and Rust was inaccurate.
+  // Most likely, this was because third-party plugins generate Gzip data without specifying `--no-name`,
+  // which embeds the file's modified timestamp and causes hash mismatches.
+  //
   // That's why, to avoid false positives, we re-upload compressed files only if their corresponding source (identity) files have changed.
   //
   // However, some files may be binary and not have an associated identity (raw) version.

--- a/packages/cli-tools/src/services/deploy.prepare.services.ts
+++ b/packages/cli-tools/src/services/deploy.prepare.services.ts
@@ -108,10 +108,17 @@ const fileNeedUpload = async ({
 
   const sha256 = await computeSha256(effectiveFilePath);
 
-  // TODO: current sha256 comparison (NodeJS vs Rust) with Gzip and BR is inaccurate. Therefore we re-upload compressed files only if their corresponding source files have been modified as well.
-  // return {file, upload: sha256 !== asset.encodings[file.encoding ?? 'identity']?.sha256};
-  // TODO: we also always assume the raw encoding is there
-  return {file, upload: sha256 !== asset.encodings.identity?.sha256};
+  // Previously, comparing the SHA-256 hash of Gzip and Brotli files between Node.js and Rust was inaccurate.
+  // That's why, to avoid false positives, we re-upload compressed files only if their corresponding source (identity) files have changed.
+  //
+  // However, some files may be binary and not have an associated identity (raw) version.
+  // In such cases, we fall back to comparing the hash of the available encoded version.
+  return {
+    file,
+    upload:
+      sha256 !==
+      (asset.encodings.identity?.sha256 ?? asset.encodings[file.encoding ?? 'identity']?.sha256)
+  };
 };
 
 const listFiles = async ({


### PR DESCRIPTION
# Motivation

I'm not sure if it's starlight or typedoc but, the build of the [documentation](https://github.com/dfinity/agent-js/tree/main/docs) of agent-js generate binary files.

e.g. `dist/core/pagefind/fragment/en_fe97e69.pf_fragment`

@ilbertt noticed that running `juno deploy` was always re-uploading those even though their content - i.e. related sha256 representation - did not changed.

After debugging, I noticed that the issue was actually related to a TODO that was left in place few years ago after implementing a solution to not reupload auto generated gzipped files.