### PR TITLE
feat(core)!: create user only on sign-in

### DIFF
--- a/packages/core/src/auth/services/_user.services.ts
+++ b/packages/core/src/auth/services/_user.services.ts
@@ -6,23 +6,13 @@ import type {Provider} from '../types/provider';
 import type {User, UserData} from '../types/user';
 import {getIdentity} from './auth.services';
 
+type UserId = string;
+
 export const initUser = async (provider?: Provider): Promise<User> => {
-  const identity = getIdentity();
+  const {user, userId} = await loadUser();
 
-  if (isNullish(identity)) {
-    throw new InitError('No identity to initialize the user. Have you initialized Juno?');
-  }
-
-  const userId = identity.getPrincipal().toText();
-
-  const loadUser = (): Promise<User | undefined> =>
-    getDoc<UserData>({
-      collection: `#user`,
-      key: userId
-    });
-
-  const user = await loadUser();
-
+  // For returning users we do not need to create a user entry.
+  // Sign-in, sign-out, and sign-in again.
   if (nonNullish(user)) {
     return user;
   }
@@ -37,7 +27,7 @@ export const initUser = async (provider?: Provider): Promise<User> => {
     // created in the meantime. To prevent errors, we reload the user data,
     // as the issue indicates the user entity exists.
     if (isSatelliteError({error, type: JUNO_DATASTORE_ERROR_USER_CANNOT_UPDATE})) {
-      const userOnCreateError = await loadUser();
+      const userOnCreateError = await getUser({userId});
 
       if (nonNullish(userOnCreateError)) {
         return userOnCreateError;
@@ -47,6 +37,29 @@ export const initUser = async (provider?: Provider): Promise<User> => {
     throw error;
   }
 };
+
+export const loadUser = async (): Promise<{userId: UserId; user: User | undefined}> => {
+  const identity = getIdentity();
+
+  if (isNullish(identity)) {
+    throw new InitError('No identity to initialize the user. Have you initialized Juno?');
+  }
+
+  const userId = identity.getPrincipal().toText();
+
+  const user = await getUser({userId});
+
+  return {
+    userId,
+    user
+  };
+};
+
+const getUser = ({userId}: {userId: UserId}): Promise<User | undefined> =>
+  getDoc<UserData>({
+    collection: `#user`,
+    key: userId
+  });
 
 const createUser = ({
   userId,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 import {assertNonNullish} from '@dfinity/utils';
 import type {Asset, AssetEncoding, AssetKey, EncodingType, Storage} from '@junobuild/storage';
 import {initAuthTimeoutWorker} from './auth/services/auth-timout.services';
-import {initAuth} from './auth/services/auth.services';
+import {loadAuth} from './auth/services/auth.services';
 import {AuthStore} from './auth/stores/auth.store';
 import type {User} from './auth/types/user';
 import {EnvStore} from './core/stores/env.store';
@@ -64,7 +64,7 @@ export const initSatellite = async (userEnv?: UserEnvironment): Promise<Unsubscr
 
   EnvStore.getInstance().set(env);
 
-  await initAuth();
+  await loadAuth();
 
   const authSubscribe =
     env.workers?.auth !== undefined ? initAuthTimeoutWorker(env.workers.auth) : undefined;


### PR DESCRIPTION
# Motivation

We have to break the flow to introduce passkeys because their registration requires more information than just the user id principal.

## Old behavior

Since day one, the library used to get and create if necessary a user either on boot - when initSatellite is called - or during/after sign-in (chained in the flow). This was handy to handle any issue as it even allowed the user to reload their window during the sign-in process since the creation of the user was handled asynchronously even in the initialization.

## New behavior

Because creating users with passkeys requires more information - notably the credential ID and the public key - we cannot just use the same approach because on initialization of the library - initSatellite - this information would be unknown. We can potentially save this information in local storage and process it but I'm afraid of the side effects of dirty states with staged data or potential security issues (what happens if someone tampers with the data). Therefore, the idea is to create the user only within the sign-in flow. To mitigate the potential issue of the user closing the window during this period, the library will provide a progress callback - this allows devs to display the progression in the UI - but also introduce a guard onbeforeunload which prompts the user to really confirm their action.
