### PR TITLE
feat(ic-client): use Uint8Array instead of number[] for aaguid

### DIFF
--- a/packages/core/src/tests/auth/services/user-webauthn.services.spec.ts
+++ b/packages/core/src/tests/auth/services/user-webauthn.services.spec.ts
@@ -1,4 +1,4 @@
-import {arrayBufferToUint8Array, jsonReviver} from '@dfinity/utils';
+import {arrayBufferToUint8Array, jsonReviver, uint8ArrayToArrayOfNumber} from '@dfinity/utils';
 import type {WebAuthnIdentity, WebAuthnNewCredential} from '@junobuild/ic-client/webauthn';
 import {MockInstance} from 'vitest';
 import {createWebAuthnUser} from '../../../auth/services/user-webauthn.services';
@@ -99,7 +99,7 @@ describe('webauthn-user.services', async () => {
         provider: 'webauthn',
         providerData: {
           webauthn: {
-            aaguid: mockWebAuthnAaguid
+            aaguid: uint8ArrayToArrayOfNumber(mockWebAuthnAaguid)
           }
         }
       });

--- a/packages/core/src/tests/mocks/webauthn.mock.ts
+++ b/packages/core/src/tests/mocks/webauthn.mock.ts
@@ -13,9 +13,9 @@ export const mockWebAuthnDocUserApiObject = {
 
 export const mockWebAuthnPubDer = new Uint8Array([9, 9, 9]).buffer;
 
-export const mockWebAuthnAaguid = [
+export const mockWebAuthnAaguid = arrayBufferToUint8Array([
   0xde, 0xad, 0xbe, 0xef, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b
-];
+]);
 
 export const mockWebAuthnDocApiObject = {
   owner: mockUserIdPrincipal,

--- a/packages/ic-client/src/tests/webauthn/aaguid.spec.ts
+++ b/packages/ic-client/src/tests/webauthn/aaguid.spec.ts
@@ -25,7 +25,7 @@ describe('AAGUID', () => {
       const aaguidBytes = hexToBytes({aaguid: aaguidText});
       const authData = makeAuthData({len: 53, aaguidBytes});
       const r = extractAAGUID({authData});
-      expect(r).toEqual({aaguidText, aaguidBytes: Array.from(aaguidBytes)});
+      expect(r).toEqual({aaguidText, aaguidBytes});
     });
 
     it('should extract correctly even when authData is longer than 53 bytes', () => {
@@ -33,7 +33,7 @@ describe('AAGUID', () => {
       const aaguidBytes = hexToBytes({aaguid: aaguidText});
       const authData = makeAuthData({len: 120, aaguidBytes});
       const r = extractAAGUID({authData});
-      expect(r).toEqual({aaguidText, aaguidBytes: Array.from(aaguidBytes)});
+      expect(r).toEqual({aaguidText, aaguidBytes});
     });
 
     it('should produce lowercase hex with hyphens', () => {
@@ -42,7 +42,7 @@ describe('AAGUID', () => {
       const authData = makeAuthData({len: 53, aaguidBytes});
       const r = extractAAGUID({authData});
       expect('aaguidText' in r && r.aaguidText === upper.toLowerCase()).toBe(true);
-      expect('aaguidBytes' in r && r.aaguidBytes).toEqual(Array.from(aaguidBytes));
+      expect('aaguidBytes' in r && r.aaguidBytes).toEqual(aaguidBytes);
     });
   });
 
@@ -60,21 +60,21 @@ describe('AAGUID', () => {
 
     it('formats non-zero bytes to canonical string', () => {
       const aaguid = '00112233-4455-6677-8899-aabbccddeeff';
-      const bytes = Array.from(hexToBytes({aaguid}));
+      const bytes = hexToBytes({aaguid});
       expect(bytesToAAGUID({bytes})).toEqual({aaguid});
     });
 
     it('outputs lowercase hex with hyphens', () => {
       const upper = 'ABCDEF12-3456-7890-ABCD-EF1234567890';
-      const bytes = Array.from(hexToBytes({aaguid: upper}));
+      const bytes = hexToBytes({aaguid: upper});
       const res = bytesToAAGUID({bytes});
       expect('aaguid' in res && res.aaguid === upper.toLowerCase()).toBe(true);
     });
 
-    it('accepts Uint8Array input', () => {
+    it('accepts numbers input', () => {
       const aaguid = 'deadbeef-0001-0203-0405-060708090a0b';
-      const u8 = hexToBytes({aaguid}); // Uint8Array
-      expect(bytesToAAGUID({bytes: u8})).toEqual({aaguid});
+      const n = Array.from(hexToBytes({aaguid}));
+      expect(bytesToAAGUID({bytes: n})).toEqual({aaguid});
     });
 
     it('returns unknownProvider for all-zero Uint8Array', () => {

--- a/packages/ic-client/src/tests/webauthn/credential.spec.ts
+++ b/packages/ic-client/src/tests/webauthn/credential.spec.ts
@@ -51,8 +51,8 @@ describe('WebAuthnCredential', () => {
       const authData = makeAuthData({len: 53, aaguidBytes: aaguidU8});
       const cred = new WebAuthnNewCredential({rawId, cose, authData});
 
-      expect(cred.getAAGUID()).toEqual(Array.from(aaguidU8)); // bytes: number[]
-      expect(cred.getAAGUIDText()).toBe(aaguid); // text
+      expect(cred.getAAGUID()).toEqual(aaguidU8);
+      expect(cred.getAAGUIDText()).toBe(aaguid);
     });
 
     it('should return undefined for zero/unknown AAGUID', () => {

--- a/packages/ic-client/src/webauthn/aaguid.ts
+++ b/packages/ic-client/src/webauthn/aaguid.ts
@@ -15,7 +15,7 @@ import {uint8ArrayToArrayOfNumber} from '@dfinity/utils';
  *
  * @param {Object} params
  * @param {Uint8Array} params.authData - The WebAuthn `authenticatorData` bytes.
- * @returns {{aaguid: string; bytes: number[]} | {invalidAuthData: null} | {unknownProvider: null}}
+ * @returns {{aaguid: string; bytes: Uint8Array} | {invalidAuthData: null} | {unknownProvider: null}}
  * - { aaguidText, aaguidBytes } for valid AAGUID
  * - { unknownProvider: null } for all-zero AAGUID
  * - { invalidAuthData: null } if `authData` is invalid (too short, too long, etc.)
@@ -27,7 +27,7 @@ export const extractAAGUID = ({
 }: {
   authData: Uint8Array;
 }):
-  | {aaguidText: string; aaguidBytes: number[]}
+  | {aaguidText: string; aaguidBytes: Uint8Array}
   | {invalidAuthData: null}
   | {unknownProvider: null} => {
   if (authData.byteLength < 37) {
@@ -38,7 +38,7 @@ export const extractAAGUID = ({
     return {invalidAuthData: null};
   }
 
-  const bytes = [...authData.slice(37, 53)];
+  const bytes = authData.slice(37, 53);
 
   const result = bytesToAAGUID({bytes});
 

--- a/packages/ic-client/src/webauthn/credential.ts
+++ b/packages/ic-client/src/webauthn/credential.ts
@@ -70,7 +70,7 @@ export abstract class WebAuthnCredential {
  */
 export class WebAuthnNewCredential extends WebAuthnCredential {
   readonly #aaguidText: string | undefined;
-  readonly #aaguidBytes: number[] | undefined;
+  readonly #aaguidBytes: Uint8Array | undefined;
 
   /**
    * @param args - {@link InitWebAuthnNewCredentialArgs} used to initialize the credential.
@@ -89,7 +89,7 @@ export class WebAuthnNewCredential extends WebAuthnCredential {
   /**
    * Returns AAGUID (Authenticator Attestation GUID).
    */
-  getAAGUID(): number[] | undefined {
+  getAAGUID(): Uint8Array | undefined {
     return this.#aaguidBytes;
   }
 


### PR DESCRIPTION
It's a bit a nicer interface. I still gonna save number[] in memory which takes a bit less space.