### PR TITLE
fix(core): process.env optional chaining not replace in NextJS

### DIFF
--- a/packages/analytics/src/utils/window.env.utils.ts
+++ b/packages/analytics/src/utils/window.env.utils.ts
@@ -11,8 +11,8 @@ export const envSatelliteId = (): string | undefined => {
         (import.meta as unknown as ImportMeta).env?.PUBLIC_SATELLITE_ID)
       : undefined;
 
-  return typeof process !== 'undefined'
-    ? (process.env?.NEXT_PUBLIC_SATELLITE_ID ?? viteEnvSatelliteId())
+  return typeof process !== 'undefined' && typeof process.env !== 'undefined'
+    ? (process.env.NEXT_PUBLIC_SATELLITE_ID ?? viteEnvSatelliteId())
     : viteEnvSatelliteId();
 };
 
@@ -24,8 +24,8 @@ export const envOrbiterId = (): string | undefined => {
         (import.meta as unknown as ImportMeta).env?.PUBLIC_ORBITER_ID)
       : undefined;
 
-  return typeof process !== 'undefined'
-    ? (process.env?.NEXT_PUBLIC_ORBITER_ID ?? viteEnvOrbiterId())
+  return typeof process !== 'undefined' && typeof process.env !== 'undefined'
+    ? (process.env.NEXT_PUBLIC_ORBITER_ID ?? viteEnvOrbiterId())
     : viteEnvOrbiterId();
 };
 
@@ -37,7 +37,7 @@ export const envContainer = (): string | undefined => {
         (import.meta as unknown as ImportMeta).env?.PUBLIC_CONTAINER)
       : undefined;
 
-  return typeof process !== 'undefined'
-    ? (process.env?.NEXT_PUBLIC_CONTAINER ?? viteEnvContainer())
+  return typeof process !== 'undefined' && typeof process.env !== 'undefined'
+    ? (process.env.NEXT_PUBLIC_CONTAINER ?? viteEnvContainer())
     : viteEnvContainer();
 };

--- a/packages/core/src/core/utils/window.env.utils.ts
+++ b/packages/core/src/core/utils/window.env.utils.ts
@@ -11,8 +11,8 @@ export const envSatelliteId = (): string | undefined => {
         (import.meta as unknown as ImportMeta).env?.PUBLIC_SATELLITE_ID)
       : undefined;
 
-  return typeof process !== 'undefined'
-    ? (process.env?.NEXT_PUBLIC_SATELLITE_ID ?? viteEnvSatelliteId())
+  return typeof process !== 'undefined' && typeof process.env !== 'undefined'
+    ? (process.env.NEXT_PUBLIC_SATELLITE_ID ?? viteEnvSatelliteId())
     : viteEnvSatelliteId();
 };
 
@@ -24,7 +24,7 @@ export const envContainer = (): string | undefined => {
         (import.meta as unknown as ImportMeta).env?.PUBLIC_CONTAINER)
       : undefined;
 
-  return typeof process !== 'undefined'
-    ? (process.env?.NEXT_PUBLIC_CONTAINER ?? viteEnvContainer())
+  return typeof process !== 'undefined' && typeof process.env !== 'undefined'
+    ? (process.env.NEXT_PUBLIC_CONTAINER ?? viteEnvContainer())
     : viteEnvContainer();
 };


### PR DESCRIPTION
It seems that newest version of NextJS does not replace anymore the `process.env` that contains an optional chaining - i.e. `process.env?.NEXT_PUBLIC_SATELLITE_ID` is not replaced but, `process.env.NEXT_PUBLIC_SATELLITE_ID` is.