### PR TITLE
feat(repo): use Principal.from instead of fromText

### DIFF
--- a/packages/admin/src/api/ic.api.ts
+++ b/packages/admin/src/api/ic.api.ts
@@ -157,7 +157,7 @@ export const canisterMetadata = async ({
   globalThis.console.warn = (): null => null;
 
   const result = await CanisterStatus.request({
-    canisterId: canisterId instanceof Principal ? canisterId : Principal.fromText(canisterId),
+    canisterId: canisterId instanceof Principal ? canisterId : Principal.from(canisterId),
     agent,
     paths: [
       {

--- a/packages/cdn/src/api/ic.api.ts
+++ b/packages/cdn/src/api/ic.api.ts
@@ -48,8 +48,7 @@ export const createSnapshot = async ({cdn}: {cdn: CdnParameters}) => {
         satellite: {satelliteId, ...rest}
       } = cdn;
       return {
-        canisterId:
-          satelliteId instanceof Principal ? satelliteId : Principal.fromText(satelliteId),
+        canisterId: satelliteId instanceof Principal ? satelliteId : Principal.from(satelliteId),
         actor: rest
       };
     }
@@ -58,7 +57,7 @@ export const createSnapshot = async ({cdn}: {cdn: CdnParameters}) => {
       console: {consoleId, ...rest}
     } = cdn;
     return {
-      canisterId: consoleId instanceof Principal ? consoleId : Principal.fromText(consoleId),
+      canisterId: consoleId instanceof Principal ? consoleId : Principal.from(consoleId),
       actor: rest
     };
   };

--- a/packages/functions/src/ic-cdk/call.ic-cdk.ts
+++ b/packages/functions/src/ic-cdk/call.ic-cdk.ts
@@ -22,10 +22,7 @@ export const call = async <T>(params: CallParams): Promise<T> => {
 
   const {canisterId: providedCanisterId, method, args: providedArgs, result: resultType} = params;
 
-  const canisterId =
-    providedCanisterId instanceof Principal
-      ? providedCanisterId.toUint8Array()
-      : providedCanisterId;
+  const canisterId = Principal.from(providedCanisterId).toUint8Array();
 
   const [argsTypes, argsValues] = (providedArgs ?? []).reduce<[IDLType[], unknown[]]>(
     ([argsTypes, argsValues], [type, value]) => [

--- a/packages/functions/src/sdk/utils/caller.utils.ts
+++ b/packages/functions/src/sdk/utils/caller.utils.ts
@@ -10,4 +10,4 @@ import type {RawUserId, UserId} from '../../schemas/satellite';
  * @returns {RawUserId} The raw user ID as a `Uint8Array`.
  */
 export const normalizeCaller = (caller: RawUserId | UserId): RawUserId =>
-  caller instanceof Principal ? caller.toUint8Array() : caller;
+  Principal.from(caller).toUint8Array();

--- a/packages/ic-client/src/utils/principal.utils.ts
+++ b/packages/ic-client/src/utils/principal.utils.ts
@@ -1,4 +1,4 @@
 import {Principal} from '@dfinity/principal';
 
 export const toPrincipal = (id: string | Principal): Principal =>
-  id instanceof Principal ? id : Principal.fromText(id);
+  id instanceof Principal ? id : Principal.from(id);


### PR DESCRIPTION
A test was failing when migrating to agentjs v3 because `toBeInstanceOf(Principal)` was returning false ([PR](https://github.com/junobuild/juno/pull/1940)). So, we want to prevent issue when trying to detect Principal.