### PR TITLE
feat(cli-tools): upload default batch size 50

### DIFF
--- a/packages/cli-tools/src/constants/deploy.constants.ts
+++ b/packages/cli-tools/src/constants/deploy.constants.ts
@@ -10,7 +10,7 @@ export const DEPLOY_DEFAULT_PRECOMPRESS: Required<Precompress> = {
 };
 
 export const IGNORE_OS_FILES = ['.ds_store', 'thumbs.db'];
-export const UPLOAD_DEFAULT_BATCH_SIZE = 20;
+export const UPLOAD_DEFAULT_BATCH_SIZE = 50;
 
 export const COLLECTION_DAPP = '#dapp';
 export const COLLECTION_CDN_RELEASES = '#_juno/releases';


### PR DESCRIPTION
With the console I noticed that a batch of 50 worked well, so let's use it as default.