### PR TITLE
feat(repo): migrate to zod v4 library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -775,14 +775,14 @@
       }
     },
     "node_modules/@dfinity/zod-schemas": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/zod-schemas/-/zod-schemas-1.1.0.tgz",
-      "integrity": "sha512-lhZTMN5bwbk+BgWA+tFto4ltrJVa+14KLssOwBtuFD980hqgP+dpAIEZQnIEZDU8x/51u2yGEpMDFubHjW2C5g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/zod-schemas/-/zod-schemas-2.1.0.tgz",
+      "integrity": "sha512-zxYwGp4M1pVslBwikIJ7nG//0hM1j0hJ97HEHHRg5P4PZnMQNyFWX/1apEiUDFVCl42/rjFEgsRustVv1HO7zg==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
         "@dfinity/principal": "*",
-        "zod": "3.25"
+        "zod": "^4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -8645,9 +8645,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.71",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.71.tgz",
-      "integrity": "sha512-BsBc/NPk7h8WsUWYWYL+BajcJPY8YhjelaWu2NMLuzgraKAz4Lb4/6K11g9jpuDetjMiqhZ6YaexFLOC0Ogi3Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -8668,7 +8668,7 @@
         "@junobuild/config": "*",
         "@junobuild/ic-client": "^3",
         "semver": "7.*",
-        "zod": "^3.25"
+        "zod": "^4"
       }
     },
     "packages/analytics": {
@@ -8771,8 +8771,8 @@
       "version": "2.2.0",
       "license": "MIT",
       "peerDependencies": {
-        "@dfinity/zod-schemas": "^1.1.0",
-        "zod": "^3.25"
+        "@dfinity/zod-schemas": "^2",
+        "zod": "^4"
       }
     },
     "packages/config-loader": {
@@ -8870,7 +8870,7 @@
         "@dfinity/identity": "^3.2.6",
         "@dfinity/principal": "^3.2.6",
         "@dfinity/utils": "^3.1",
-        "zod": "^3.25"
+        "zod": "^4"
       }
     },
     "packages/ic-client": {
@@ -9348,9 +9348,9 @@
       "requires": {}
     },
     "@dfinity/zod-schemas": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/zod-schemas/-/zod-schemas-1.1.0.tgz",
-      "integrity": "sha512-lhZTMN5bwbk+BgWA+tFto4ltrJVa+14KLssOwBtuFD980hqgP+dpAIEZQnIEZDU8x/51u2yGEpMDFubHjW2C5g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/zod-schemas/-/zod-schemas-2.1.0.tgz",
+      "integrity": "sha512-zxYwGp4M1pVslBwikIJ7nG//0hM1j0hJ97HEHHRg5P4PZnMQNyFWX/1apEiUDFVCl42/rjFEgsRustVv1HO7zg==",
       "peer": true,
       "requires": {}
     },
@@ -14268,9 +14268,9 @@
       "peer": true
     },
     "zod": {
-      "version": "3.25.71",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.71.tgz",
-      "integrity": "sha512-BsBc/NPk7h8WsUWYWYL+BajcJPY8YhjelaWu2NMLuzgraKAz4Lb4/6K11g9jpuDetjMiqhZ6YaexFLOC0Ogi3Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
       "peer": true
     }
   }

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -59,6 +59,6 @@
     "@junobuild/config": "*",
     "@junobuild/ic-client": "^3",
     "semver": "7.*",
-    "zod": "^3.25"
+    "zod": "^4"
   }
 }

--- a/packages/admin/src/schemas/build.ts
+++ b/packages/admin/src/schemas/build.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * Represents the type of build, stock or extended.

--- a/packages/admin/src/schemas/releases.ts
+++ b/packages/admin/src/schemas/releases.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * A schema for validating a version string in `x.y.z` format.

--- a/packages/admin/src/services/package.services.ts
+++ b/packages/admin/src/services/package.services.ts
@@ -2,7 +2,7 @@ import type {Principal} from '@dfinity/principal';
 import {isNullish} from '@dfinity/utils';
 import {type JunoPackage, JunoPackageSchema} from '@junobuild/config';
 import type {ActorParameters} from '@junobuild/ic-client/actor';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {canisterMetadata} from '../api/ic.api';
 
 /**

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://juno.build",
   "peerDependencies": {
-    "@dfinity/zod-schemas": "^1.1.0",
-    "zod": "^3.25"
+    "@dfinity/zod-schemas": "^2",
+    "zod": "^4"
   }
 }

--- a/packages/config/src/cli/run.context.ts
+++ b/packages/config/src/cli/run.context.ts
@@ -1,6 +1,6 @@
 import type {Identity} from '@dfinity/agent';
 import type {Principal} from '@dfinity/principal';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {StrictIdentitySchema} from '../utils/identity.utils';
 import {StrictPrincipalSchema} from '../utils/principal.utils';
 import {createFunctionSchema} from '../utils/zod.utils';

--- a/packages/config/src/cli/run.env.ts
+++ b/packages/config/src/cli/run.env.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {type JunoConfigEnv, JunoConfigEnvSchema} from '../types/juno.env';
 
 /**

--- a/packages/config/src/cli/run.ts
+++ b/packages/config/src/cli/run.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {createFunctionSchema} from '../utils/zod.utils';
 import {type OnRun, OnRunContextSchema, OnRunSchema} from './run.context';
 import type {OnRunEnv} from './run.env';

--- a/packages/config/src/console/console.config.ts
+++ b/packages/config/src/console/console.config.ts
@@ -1,5 +1,5 @@
 import {type PrincipalText, PrincipalTextSchema} from '@dfinity/zod-schemas';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {type StorageConfig, StorageConfigSchema} from '../shared/storage.config';
 import {type CliConfig, CliConfigSchema} from '../types/cli.config';
 import {type JunoConfigMode, JunoConfigModeSchema} from '../types/juno.env';

--- a/packages/config/src/pkg/juno.package.ts
+++ b/packages/config/src/pkg/juno.package.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * @see JunoPackageDependencies

--- a/packages/config/src/satellite/configs/assertions.config.ts
+++ b/packages/config/src/satellite/configs/assertions.config.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * @see SatelliteAssertions

--- a/packages/config/src/satellite/configs/authentication.config.ts
+++ b/packages/config/src/satellite/configs/authentication.config.ts
@@ -1,5 +1,5 @@
 import {type PrincipalText, PrincipalTextSchema} from '@dfinity/zod-schemas';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * @see AuthenticationConfigInternetIdentity

--- a/packages/config/src/satellite/configs/collections.ts
+++ b/packages/config/src/satellite/configs/collections.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {type Rule, RuleSchema} from './rules';
 
 /**

--- a/packages/config/src/satellite/configs/datastore.config.ts
+++ b/packages/config/src/satellite/configs/datastore.config.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {type MaxMemorySizeConfig, MaxMemorySizeConfigSchema} from '../../shared/feature.config';
 
 /**

--- a/packages/config/src/satellite/configs/emulator.config.ts
+++ b/packages/config/src/satellite/configs/emulator.config.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 const EmulatorPortsSchema = z.strictObject({
   /**

--- a/packages/config/src/satellite/configs/module.settings.ts
+++ b/packages/config/src/satellite/configs/module.settings.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * @see ModuleLogVisibility

--- a/packages/config/src/satellite/configs/orbiter.config.ts
+++ b/packages/config/src/satellite/configs/orbiter.config.ts
@@ -1,5 +1,5 @@
 import {type PrincipalText, PrincipalTextSchema} from '@dfinity/zod-schemas';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {type JunoConfigMode, JunoConfigModeSchema} from '../../types/juno.env';
 import type {Either} from '../../types/utility.types';
 import {StrictPrincipalTextSchema} from '../../utils/principal.utils';

--- a/packages/config/src/satellite/configs/rules.ts
+++ b/packages/config/src/satellite/configs/rules.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * @see PermissionText

--- a/packages/config/src/satellite/configs/satellite.config.ts
+++ b/packages/config/src/satellite/configs/satellite.config.ts
@@ -1,5 +1,5 @@
 import {type PrincipalText, PrincipalTextSchema} from '@dfinity/zod-schemas';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {type StorageConfig, StorageConfigSchema} from '../../shared/storage.config';
 import type {CliConfig} from '../../types/cli.config';
 import {type JunoConfigMode, JunoConfigModeSchema} from '../../types/juno.env';

--- a/packages/config/src/satellite/juno.config.ts
+++ b/packages/config/src/satellite/juno.config.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {type EmulatorConfig, EmulatorConfigSchema} from './configs/emulator.config';
 import {type OrbiterConfig, OrbiterConfigSchema} from './configs/orbiter.config';
 import {type SatelliteConfig, SatelliteConfigOptionsSchema} from './configs/satellite.config';

--- a/packages/config/src/shared/feature.config.ts
+++ b/packages/config/src/shared/feature.config.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * @see MaxMemorySizeConfig

--- a/packages/config/src/shared/storage.config.ts
+++ b/packages/config/src/shared/storage.config.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {type MaxMemorySizeConfig, MaxMemorySizeConfigSchema} from './feature.config';
 
 /**

--- a/packages/config/src/types/cli.config.ts
+++ b/packages/config/src/types/cli.config.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {type EncodingType, EncodingTypeSchema} from './encoding';
 
 /**

--- a/packages/config/src/types/encoding.ts
+++ b/packages/config/src/types/encoding.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * see EncodingType

--- a/packages/config/src/types/juno.env.ts
+++ b/packages/config/src/types/juno.env.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * @see JunoConfigMode

--- a/packages/config/src/utils/identity.utils.ts
+++ b/packages/config/src/utils/identity.utils.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {StrictPrincipalSchema} from './principal.utils';
 
 /**

--- a/packages/config/src/utils/principal.utils.ts
+++ b/packages/config/src/utils/principal.utils.ts
@@ -1,6 +1,6 @@
 import {Principal} from '@dfinity/principal';
 import {PrincipalTextSchema} from '@dfinity/zod-schemas';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * Ensures reliable validation of PrincipalTextSchema inside z.record.

--- a/packages/config/src/utils/zod.utils.ts
+++ b/packages/config/src/utils/zod.utils.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 // TODO: Workaround source: https://github.com/colinhacks/zod/issues/4143#issuecomment-2845134912
 // TODO: Duplicates the helper in @junobuild/functions. Both should be removed once we migrate to latest v4 version of Zod

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -51,6 +51,6 @@
     "@dfinity/identity": "^3.2.6",
     "@dfinity/principal": "^3.2.6",
     "@dfinity/utils": "^3.1",
-    "zod": "^3.25"
+    "zod": "^4"
   }
 }

--- a/packages/functions/src/hooks/assertions.ts
+++ b/packages/functions/src/hooks/assertions.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {createFunctionSchema} from '../utils/zod.utils';
 import {type Collections, CollectionsSchema} from './schemas/collections';
 import {type AssertFunction, AssertFunctionSchema} from './schemas/context';

--- a/packages/functions/src/hooks/hooks.ts
+++ b/packages/functions/src/hooks/hooks.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {createFunctionSchema} from '../utils/zod.utils';
 import {type Collections, CollectionsSchema} from './schemas/collections';
 import {type RunFunction, RunFunctionSchema} from './schemas/context';

--- a/packages/functions/src/hooks/schemas/collections.ts
+++ b/packages/functions/src/hooks/schemas/collections.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import type {Collection} from '../../schemas/satellite';
 
 /**

--- a/packages/functions/src/hooks/schemas/context.ts
+++ b/packages/functions/src/hooks/schemas/context.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {type RawUserId, RawUserIdSchema} from '../../schemas/satellite';
 import {createFunctionSchema} from '../../utils/zod.utils';
 

--- a/packages/functions/src/hooks/schemas/db/context.ts
+++ b/packages/functions/src/hooks/schemas/db/context.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {DocSchema, type OptionDoc} from '../../../schemas/db';
 import {type Collection, CollectionSchema, type Key, KeySchema} from '../../../schemas/satellite';
 import {type HookContext, HookContextSchema} from '../context';

--- a/packages/functions/src/hooks/schemas/db/payload.ts
+++ b/packages/functions/src/hooks/schemas/db/payload.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {
   type DelDoc,
   DelDocSchema,

--- a/packages/functions/src/hooks/schemas/satellite.env.ts
+++ b/packages/functions/src/hooks/schemas/satellite.env.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * @see SatelliteEnv

--- a/packages/functions/src/hooks/schemas/storage/context.ts
+++ b/packages/functions/src/hooks/schemas/storage/context.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {AssetSchema, type Asset} from '../../../schemas/storage';
 import {HookContextSchema, type HookContext} from '../context';
 import {AssetAssertUploadSchema, type AssetAssertUpload} from './payload';

--- a/packages/functions/src/hooks/schemas/storage/payload.ts
+++ b/packages/functions/src/hooks/schemas/storage/payload.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {
   type Asset,
   AssetSchema,

--- a/packages/functions/src/ic-cdk/schemas/call.ts
+++ b/packages/functions/src/ic-cdk/schemas/call.ts
@@ -1,6 +1,6 @@
 import {IDL} from '@dfinity/candid';
 import type {Principal} from '@dfinity/principal';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {PrincipalSchema, type RawPrincipal, RawPrincipalSchema} from '../../schemas/candid';
 
 /**

--- a/packages/functions/src/schemas/candid.ts
+++ b/packages/functions/src/schemas/candid.ts
@@ -1,5 +1,5 @@
 import {Principal as CandidPrincipal} from '@dfinity/principal';
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * A schema that validates a value is an Uint8Array.

--- a/packages/functions/src/schemas/db.ts
+++ b/packages/functions/src/schemas/db.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {Uint8ArraySchema} from './candid';
 import {
   type Description,

--- a/packages/functions/src/schemas/list.ts
+++ b/packages/functions/src/schemas/list.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {
   type Description,
   type Key,

--- a/packages/functions/src/schemas/satellite.ts
+++ b/packages/functions/src/schemas/satellite.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {PrincipalSchema, RawPrincipalSchema} from './candid';
 
 /**

--- a/packages/functions/src/schemas/storage.ts
+++ b/packages/functions/src/schemas/storage.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {Uint8ArraySchema} from './candid';
 import {
   type Collection,

--- a/packages/functions/src/sdk/schemas/collections.ts
+++ b/packages/functions/src/sdk/schemas/collections.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 /**
  * @see Memory

--- a/packages/functions/src/sdk/schemas/controllers.ts
+++ b/packages/functions/src/sdk/schemas/controllers.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {RawPrincipalSchema} from '../../schemas/candid';
 import {
   type RawUserId,

--- a/packages/functions/src/sdk/schemas/params.ts
+++ b/packages/functions/src/sdk/schemas/params.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {type ListParams, ListParamsSchema} from '../../schemas/list';
 import {
   type Collection,

--- a/packages/functions/src/sdk/schemas/storage.ts
+++ b/packages/functions/src/sdk/schemas/storage.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {type RawUserId, type UserId, RawUserIdSchema, UserIdSchema} from '../../schemas/satellite';
 import {
   type AssetEncoding,

--- a/packages/functions/src/tests/hooks/schemas/context.spec.ts
+++ b/packages/functions/src/tests/hooks/schemas/context.spec.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {
   AssertFunctionSchema,
   HookContextSchema,

--- a/packages/functions/src/tests/hooks/schemas/db/context.spec.ts
+++ b/packages/functions/src/tests/hooks/schemas/db/context.spec.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {
   AssertDeleteDocContextSchema,
   AssertSetDocContextSchema,

--- a/packages/functions/src/tests/schemas/db.spec.ts
+++ b/packages/functions/src/tests/schemas/db.spec.ts
@@ -1,5 +1,5 @@
 import {Principal} from '@dfinity/principal';
-import {ZodError} from 'zod/v4';
+import {ZodError} from 'zod';
 import {
   DelDocSchema,
   DocSchema,

--- a/packages/functions/src/tests/schemas/list.spec.ts
+++ b/packages/functions/src/tests/schemas/list.spec.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 import {
   ListMatcherSchema,
   ListOrderFieldSchema,

--- a/packages/functions/src/tests/schemas/storage.spec.ts
+++ b/packages/functions/src/tests/schemas/storage.spec.ts
@@ -1,5 +1,5 @@
 import {Principal} from '@dfinity/principal';
-import {ZodError} from 'zod/v4';
+import {ZodError} from 'zod';
 import {
   type Asset,
   AssetEncodingSchema,

--- a/packages/functions/src/tests/sdk/db.sdk.spec.ts
+++ b/packages/functions/src/tests/sdk/db.sdk.spec.ts
@@ -1,5 +1,5 @@
 import {Principal} from '@dfinity/principal';
-import {ZodError} from 'zod/v4';
+import {ZodError} from 'zod';
 import {
   countCollectionDocsStore,
   countDocsStore,

--- a/packages/functions/src/tests/sdk/schemas/storage.spec.ts
+++ b/packages/functions/src/tests/sdk/schemas/storage.spec.ts
@@ -1,5 +1,5 @@
 import {Principal} from '@dfinity/principal';
-import {ZodError} from 'zod/v4';
+import {ZodError} from 'zod';
 import {
   CountAssetsStoreParamsSchema,
   CountCollectionAssetsStoreParamsSchema,

--- a/packages/functions/src/tests/sdk/storage.sdk.spec.ts
+++ b/packages/functions/src/tests/sdk/storage.sdk.spec.ts
@@ -1,5 +1,5 @@
 import {Principal} from '@dfinity/principal';
-import {ZodError} from 'zod/v4';
+import {ZodError} from 'zod';
 import {
   CountAssetsStoreParams,
   CountCollectionAssetsStoreParams,

--- a/packages/functions/src/utils/zod.utils.ts
+++ b/packages/functions/src/utils/zod.utils.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod/v4';
+import * as z from 'zod';
 
 // TODO: Workaround source: https://github.com/colinhacks/zod/issues/4143#issuecomment-2845134912
 export const createFunctionSchema = <T extends z.core.$ZodFunction>(schema: T) =>


### PR DESCRIPTION
OISY can finally be migrated to zod v4 as the ecosystem has been upgraded (https://github.com/dfinity/oisy-wallet/pull/9146)
Per extension we can migrate the OISY Wallet Signer.
And finally per extension I can migrate the Juno Console, so the Juno libs as well.